### PR TITLE
Add Remulos to the server list

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -48,7 +48,7 @@ local COMM_COMMANDS = {nil, "ADD", nil}
 
 --stuff
 local PLAYER_NAME, _ = nil
-local HARDCORE_REALMS = {"Bloodsail Buccaneers", "Hydraxian Waterlords"}
+local HARDCORE_REALMS = {"Bloodsail Buccaneers", "Hydraxian Waterlords", "Remulos"}
 local GENDER_GREETING = {"guildmate", "brother", "sister"}
 local recent_levelup = nil
 local Last_Attack_Source = nil


### PR DESCRIPTION
Some love for the OCE community. Adds `Remulos` to the hardcore
server list so the addon auto-enables on login.

Without this, you need to manually enable every session.