### PR TITLE
Grief alert

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -463,10 +463,10 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 				if faction ~= nil then
 					if faction ~= PLAYER_FACTION then
 						local target_name, _ = UnitName("target")
-						Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+						Hardcore:ShowAlertFrame(ALERT_STYLES.hc_red, "Target " .. target_name .. " is PvP enabled!")
 					elseif UnitPlayerControlled("target") then
 						local target_name, _ = UnitName("target")
-						Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+						Hardcore:ShowAlertFrame(ALERT_STYLES.hc_red, "Target " .. target_name .. " is PvP enabled!")
 					end
 				end
 			end
@@ -476,7 +476,7 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 				if faction ~= nil then
 					if (faction ~= PLAYER_FACTION) then
 						local target_name, _ = UnitName("target")
-						Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+						Hardcore:ShowAlertFrame(ALERT_STYLES.hc_red, "Target " .. target_name .. " is PvP enabled!")
 					end
 				end
 			end
@@ -486,7 +486,7 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 				if faction ~= nil then
 					if faction == PLAYER_FACTION and UnitPlayerControlled("target") then
 						local target_name, _ = UnitName("target")
-						Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+						Hardcore:ShowAlertFrame(ALERT_STYLES.hc_red, "Target " .. target_name .. " is PvP enabled!")
 					end
 				end
 			end

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -285,7 +285,7 @@ function Hardcore:PLAYER_LOGIN()
 	_, class, _ = UnitClass("player")
 	PLAYER_NAME, _ = UnitName("player")
 	PLAYER_GUID = UnitGUID("player")
-  PLAYER_FACTION, _ = UnitFactionGroup("player")
+	PLAYER_FACTION, _ = UnitFactionGroup("player")
 	local PLAYER_LEVEL = UnitLevel("player")
 
 	-- fires on first loading
@@ -405,25 +405,25 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 		C_ChatInfo.RegisterAddonMessagePrefix(COMM_NAME)
 	end
 
-  -- Hook TargetFrame classification and warn if PvP enabled and enemy faction 
-  hooksecurefunc("TargetFrame_CheckClassification",function(self, lock)
-    if Hardcore_Settings.grief_warning_conditions == PVP then
-      if UnitIsPVP("target") and UnitGUID("target") ~= PLAYER_GUID then
-        local target_name, _ = UnitName("target")
-        Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
-      end
-    elseif Hardcore_Settings.grief_warning_conditions == PVP_AND_ENEMY_FACTION then
-      if UnitGUID("target") ~= PLAYER_GUID and UnitIsPVP("target")  then 
-        local faction, _ = UnitFactionGroup("target")
-        if faction ~= nil then
-          if (faction == "Horde" and PLAYER_FACTION == "Alliance") or (faction == "Alliance" and PLAYER_FACTION == "Horde") then
-            local target_name, _ = UnitName("target")
-            Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
-          end
-        end
-      end
-    end
-  end);
+	-- Hook TargetFrame classification and warn if PvP enabled and enemy faction 
+	hooksecurefunc("TargetFrame_CheckClassification",function(self, lock)
+		if Hardcore_Settings.grief_warning_conditions == PVP then
+			if UnitIsPVP("target") and UnitGUID("target") ~= PLAYER_GUID then
+				local target_name, _ = UnitName("target")
+				Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+			end
+		elseif Hardcore_Settings.grief_warning_conditions == PVP_AND_ENEMY_FACTION then
+			if UnitGUID("target") ~= PLAYER_GUID and UnitIsPVP("target")  then 
+				local faction, _ = UnitFactionGroup("target")
+				if faction ~= nil then
+					if (faction~=PLAYER_FACTION) then
+						local target_name, _ = UnitName("target")
+						Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+					end
+				end
+			end
+		end
+	end);
 end
 
 function Hardcore:PLAYER_ALIVE()

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -407,11 +407,21 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 
   -- Hook TargetFrame classification and warn if PvP enabled and enemy faction 
   hooksecurefunc("TargetFrame_CheckClassification",function(self, lock)
-    if (Hardcore_Settings.grief_warning_conditions == PVP and UnitIsPvP("target")) or
-       (Hardcore_Settings.grief_warning_conditions == PVP_AND_ENEMY_FACTION and
-         UnitIsPvP("target") and PLAYER_FACTION ~= UnitFactionGroup("target")[1]) then 
-      local target_name, _ = UnitName("target")
-      ShowAlert("hc_red", "Target " .. target_name .. " is PvP enabled!")
+    if Hardcore_Settings.grief_warning_conditions == PVP then
+      if UnitIsPVP("target") and UnitGUID("target") ~= PLAYER_GUID then
+        local target_name, _ = UnitName("target")
+        Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+      end
+    elseif Hardcore_Settings.grief_warning_conditions == PVP_AND_ENEMY_FACTION then
+      if UnitGUID("target") ~= PLAYER_GUID and UnitIsPVP("target")  then 
+        local faction, _ = UnitFactionGroup("target")
+        if faction ~= nil then
+          if (faction == "Horde" and PLAYER_FACTION == "Alliance") or (faction == "Alliance" and PLAYER_FACTION == "Horde") then
+            local target_name, _ = UnitName("target")
+            Hardcore:ShowAlertFrame("hc_red", "Target " .. target_name .. " is PvP enabled!")
+          end
+        end
+      end
     end
   end);
 end


### PR DESCRIPTION
Shows alert message if target is pvp enabled or pvp enabled and enemy factions. 

Default settings is off and won't be exposed until config options.