### PR TITLE
set version to 0.5.0-rc1 and tweak Author string

### DIFF
--- a/Hardcore.toc
+++ b/Hardcore.toc
@@ -1,8 +1,8 @@
 ## Interface: 11400
 ## Version: 0.5.0-rc1
 ## Title: Hardcore
-## Notes: Notify the guild on players death or ressurection
-## Author: The Classic Hardcore team, and Molikar (Sean Kennedy)
+## Notes: Supports Classic Hardcore / Road to Ragnaros play
+## Author: The Classic Hardcore team, Molikar (Sean Kennedy)
 ## X-License: All Rights Reserved
 ## X-Category: Leveling
 

--- a/Hardcore.toc
+++ b/Hardcore.toc
@@ -1,8 +1,8 @@
 ## Interface: 11400
-## Version: 0.4.0
+## Version: 0.5.0-rc1
 ## Title: Hardcore
 ## Notes: Notify the guild on players death or ressurection
-## Author: Molikar (Sean Kennedy)
+## Author: The Classic Hardcore team, and Molikar (Sean Kennedy)
 ## X-License: All Rights Reserved
 ## X-Category: Leveling
 


### PR DESCRIPTION
Adjusting our defaults to be version 0.5.0-rc1 for interface 11400. Notes and Author fields also updated.

## Interface: 11400
## Version: 0.5.0-rc1
## Title: Hardcore
## Notes: Supports Classic Hardcore / Road to Ragnaros play
## Author: The Classic Hardcore team, Molikar (Sean Kennedy)
## X-License: All Rights Reserved

