### PR TITLE
fix: bug that resulted in some deaths getting counted twice

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -220,6 +220,8 @@ end
 --[[ Events ]]--
 
 function Hardcore:PLAYER_LOGIN()
+	Hardcore:HandleLegacyDeaths()
+
 	-- cache player data
 	_, class, _ = UnitClass("player")
 	PLAYER_NAME, _ = UnitName("player")
@@ -1350,6 +1352,19 @@ function Hardcore:FetchGuildRoster()
 
 		num_ellipsis = num_ellipsis + 1
 	end)
+end
+
+function Hardcore:HandleLegacyDeaths()
+	if type(Hardcore_Character.deaths) == "number" then
+		local deathcount = Hardcore_Character.deaths
+		Hardcore_Character.deaths = {}
+		for i = 1, deathcount do
+			table.insert(Hardcore_Character.deaths, {
+				player_dead_trigger = date("%m/%d/%y %H:%M:%S"),
+				player_alive_trigger = date("%m/%d/%y %H:%M:%S")
+			})
+		end
+	end
 end
 
 --[[ Timers ]]--

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -370,8 +370,6 @@ function Hardcore:PLAYER_DEAD()
 	C_Timer.After(PICTURE_DELAY, Screenshot)
 
 	-- Update deaths
-
-
 	if #Hardcore_Character.deaths == 0 or (#Hardcore_Character.deaths > 0 and Hardcore_Character.deaths[#Hardcore_Character.deaths].player_alive_trigger ~= nil) then
 		table.insert(Hardcore_Character.deaths, {
 			player_dead_trigger = date("%m/%d/%y %H:%M:%S"),

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -31,7 +31,7 @@ Hardcore_Character = {
 	time_played = 0, -- seconds
 	accumulated_time_diff = 0, -- seconds
 	tracked_played_percentage = 0,
-	deaths = 0,
+	deaths = {},
 	bubble_hearth_incidents = {},
 	played_time_gap_warnings = {},
 }
@@ -228,6 +228,7 @@ function Hardcore:PLAYER_LOGIN()
 
 	-- fires on first loading
 	self:RegisterEvent("PLAYER_UNGHOST")
+	self:RegisterEvent("PLAYER_ALIVE")
 	self:RegisterEvent("PLAYER_DEAD")
 	self:RegisterEvent("CHAT_MSG_ADDON")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
@@ -250,7 +251,7 @@ function Hardcore:PLAYER_LOGIN()
 			time_played = 0,
 			accumulated_time_diff = 0,
 			tracked_played_percentage = 0,
-			deaths = 0,
+			deaths = {},
 			bubble_hearth_incidents = {},
 			played_time_gap_warnings ={}
 		}
@@ -350,6 +351,16 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 	end
 end
 
+function Hardcore:PLAYER_ALIVE()
+	if #Hardcore_Character.deaths == 0 then
+		return
+	end
+
+	if Hardcore_Character.deaths[#Hardcore_Character.deaths].player_alive_trigger == nil then
+		Hardcore_Character.deaths[#Hardcore_Character.deaths].player_alive_trigger = date("%m/%d/%y %H:%M:%S")
+	end
+end
+
 function Hardcore:PLAYER_DEAD()
 	if Hardcore_Settings.enabled == false then
 		return
@@ -358,8 +369,15 @@ function Hardcore:PLAYER_DEAD()
 	-- screenshot
 	C_Timer.After(PICTURE_DELAY, Screenshot)
 
-	-- Update death count
-	Hardcore_Character.deaths = Hardcore_Character.deaths + 1
+	-- Update deaths
+
+
+	if #Hardcore_Character.deaths == 0 or (#Hardcore_Character.deaths > 0 and Hardcore_Character.deaths[#Hardcore_Character.deaths].player_alive_trigger ~= nil) then
+		table.insert(Hardcore_Character.deaths, {
+			player_dead_trigger = date("%m/%d/%y %H:%M:%S"),
+			player_alive_trigger = nil
+		})
+	end
 
 	-- Get information
 	local playerId = UnitGUID("player")
@@ -1194,7 +1212,7 @@ function Hardcore:GenerateVerificationString()
 
 	local baseVerificationData = {Hardcore_Character.guid, realm, race, class, name, level,
 									Hardcore_Character.time_played, Hardcore_Character.time_tracked,
-									Hardcore_Character.deaths}
+									#Hardcore_Character.deaths}
 	local baseVerificationString = Hardcore_join(Hardcore_map(baseVerificationData, Hardcore_stringOrNumberToUnicode),
 		ATTRIBUTE_SEPARATOR)
 	local bubbleHearthIncidentsVerificationString = Hardcore_tableToUnicode(Hardcore_Character.bubble_hearth_incidents)


### PR DESCRIPTION
## Problem
The `PLAYER_DEAD` event triggers when:
- A player dies
- A player logs out after dying without releasing their spirit and logging back in

This leads to some deaths getting counted twice.

## Solution
In addition to updating deaths, I added an additional check using the `PLAYER_ALIVE` event. This event triggers when:
- A player releases their spirit (either by pressing the button, or automatically after logging in dead after they logged out without releasing their spirit).
- There are other cases where this event triggers, e.g. on every log in. Unfortunately there is no complete documentation on this 😕 

From my understanding and testing, it looks like every `PLAYER_DEAD` event is followed by exactly one `PLAYER_ALIVE` event.
- Either because the player pressed the release spirit button
- Or because the player logged out before releasing and logged back in

My solution is to "verify" a death using the `PLAYER_ALIVE` event, meaning when 2 consecutive  `PLAYER_DEAD` events are fired without having a `PLAYER_ALIVE` event in between, the second `PLAYER_DEAD` does not update deaths.

## Tests
The following cases work, meaning they only count as one death:
- Die, logout before releasing, log back in
- Die, release spirit
- Die, release spirit, reload UI while dead
- Die, release spirit, logout and back in

Not sure if there are any other potential edge cases we should test. Feedback appreciated!