### PR TITLE
Adds debug logging and spam protection

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -754,8 +754,7 @@ function Hardcore:CHAT_MSG_ADDON(prefix, datastr, scope, sender)
 	if COMM_NAME == prefix then
 		-- Get the command
 		local command, data = string.split(COMM_COMMAND_DELIM, datastr)
-		if DEPRECATED_COMMANDS[command] then return end
-		if alert_msg_time[command] == nil then return end
+		if DEPRECATED_COMMANDS[command] or alert_msg_time[command] == nil then return end
 		if alert_msg_time[command][sender] and (time() - alert_msg_time[command][sender] < COMM_SPAM_THRESHOLD[command]) then
 			local debug_info = {command, data, sender}
 			table.insert(Hardcore_Settings.debug_log, debug_info)

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -66,13 +66,11 @@ local alert_msg_time = {
 	PULSE = {},
 	ADD = {},
 	DEAD = {},
-	UNKNOWN = {},
 }
 local monitor_msg_throttle = {
 	PULSE = {},
 	ADD = {},
 	DEAD = {},
-	UNKNOWN = {},
 }
 local online_pulsing = {}
 local guild_versions = {}
@@ -757,20 +755,7 @@ function Hardcore:CHAT_MSG_ADDON(prefix, datastr, scope, sender)
 		-- Get the command
 		local command, data = string.split(COMM_COMMAND_DELIM, datastr)
 		if DEPRECATED_COMMANDS[command] then return end
-
-		-- Handle weird commands
-		if alert_msg_time[command] == nil then
-			local debug_info = {command, data, sender}
-			table.insert(Hardcore_Settings.debug_log, debug_info)
-			alert_msg_time.UNKNOWN[sender] = time()
-			-- Display that someone is trying to send unknown messages; notifies mods to look at saved_vars and remove player from guild
-			if monitor_msg_throttle.UNKNOWN[sender] == nil or (time() - monitor_msg_throttle.UNKNOWN[sender] > THROTTLE_DURATION) then
-				Hardcore:Monitor("|cffFF0000Received unknown messages from " .. sender .. ".")
-				monitor_msg_throttle.UNKNOWN[sender] = time()
-			end
-			return
-		end
-
+		if alert_msg_time[command] == nil then return end
 		if alert_msg_time[command][sender] and (time() - alert_msg_time[command][sender] < COMM_SPAM_THRESHOLD[command]) then
 			local debug_info = {command, data, sender}
 			table.insert(Hardcore_Settings.debug_log, debug_info)

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -235,7 +235,6 @@ local function SlashHandler(msg, editbox)
 		end
 	elseif cmd == "monitor" then
 		Hardcore_Settings.monitor = not Hardcore_Settings.monitor
-		Hardcore_Toggle_Alerts()
 		if Hardcore_Settings.monitor then
 			Hardcore:Monitor("Monitoring malicious users enabled.")
 		else
@@ -506,9 +505,7 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 	-- cache player name
 	PLAYER_NAME, _ = UnitName("player")
 	Hardcore:PrintBubbleHearthInfractions()
-	if Hardcore_Settings.monitor == true then
-		Hardcore:Monitor("Monitoring malicious users enabled.")
-	end
+	Hardcore:Monitor("Monitoring malicious users enabled.")
 
 	-- initialize addon communication
 	if (not C_ChatInfo.IsAddonMessagePrefixRegistered(COMM_NAME)) then

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -105,6 +105,7 @@ local COMM_SPAM_THRESHOLD = { -- msgs received within durations (s) are flagged 
 }
 local DEPRECATED_COMMANDS = {
 	UPDATE = 1,
+	SYNC = 1,
 }
 
 -- stuff
@@ -749,8 +750,10 @@ function Hardcore:CHAT_MSG_ADDON(prefix, datastr, scope, sender)
 	if COMM_NAME == prefix then
 		-- Get the command
 		local command, data = string.split(COMM_COMMAND_DELIM, datastr)
+		if DEPRECATED_COMMANDS[command] then return end
 
-		if alert_msg_time[command] == nil and DEPRECATED_COMMANDS[command] == nil then -- unknown command received
+		-- Handle weird commands
+		if alert_msg_time[command] == nil then
 			local debug_info = {command, data, sender}
 			table.insert(Hardcore_Settings.debug_log, debug_info)
 			alert_msg_time.UNKNOWN[sender] = time()


### PR DESCRIPTION
* Adds a debug log.  When malicious player is detected, a mod can log off and view log in saved variables.  The debug log is cleared upon logging back in
* Adds minimum duration for time between sent messages of each command
* Notifies user if they are being spammed with a single chat message if monitor is on. This might help mods investigate attackers