### PR TITLE
Death Alert Grief protection

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -23,18 +23,18 @@ local GRIEF_WARNING_SAME_FACTION = 1
 local GRIEF_WARNING_ENEMY_FACTION = 2
 local GRIEF_WARNING_BOTH_FACTIONS = 3
 local CLASSES = {
-		-- Classic:
-		[1] = "Warrior",
-		[2] = "Paladin",
-		[3] = "Hunter",
-		[4] = "Rogue",
-		[5] = "Priest",
-		[7] = "Shaman",
-		[8] = "Mage",
-		[9] = "Warlock",
-		[11] = "Druid",
-		-- WotLK:
-		[6] = "Death Knight"
+	-- Classic:
+	[1] = "Warrior",
+	[2] = "Paladin",
+	[3] = "Hunter",
+	[4] = "Rogue",
+	[5] = "Priest",
+	[7] = "Shaman",
+	[8] = "Mage",
+	[9] = "Warlock",
+	[11] = "Druid",
+	-- WotLK:
+	[6] = "Death Knight"
 }
 
 --[[ Global saved variables ]]--
@@ -473,8 +473,8 @@ function Hardcore:UNIT_SPELLCAST_SUCCEEDED(...)
 end
 
 function Hardcore:PLAYER_ENTERING_WORLD()
-		Hardcore_Frame:RegisterForDrag("LeftButton")
-		Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
+	Hardcore_Frame:RegisterForDrag("LeftButton")
+	Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
 		
 	-- cache player name
 	PLAYER_NAME, _ = UnitName("player")
@@ -509,12 +509,12 @@ function Hardcore:PLAYER_DEAD()
 	end
 
 	-- Send message to guild
-		local playerGreet = GENDER_GREETING[UnitSex("player")]
-		local name = UnitName("player")
-		local _, _, classID = UnitClass("player")
-		local class = CLASSES[classID]
-		local level = UnitLevel("player")
-		local zone = C_Map.GetMapInfo(C_Map.GetBestMapForUnit("player")).name
+	local playerGreet = GENDER_GREETING[UnitSex("player")]
+	local name = UnitName("player")
+	local _, _, classID = UnitClass("player")
+	local class = CLASSES[classID]
+	local level = UnitLevel("player")
+	local zone = C_Map.GetMapInfo(C_Map.GetBestMapForUnit("player")).name
 	local messageFormat = "Our brave %s, %s the %s, has died at level %d in %s"
 	local messageString = messageFormat:format(playerGreet, name, class, level, zone)
 	if not (Last_Attack_Source == nil) then
@@ -523,7 +523,7 @@ function Hardcore:PLAYER_DEAD()
 	end
 	SendChatMessage(messageString, "GUILD")
 
-		-- Send addon message
+	-- Send addon message
 	local commMessage = COMM_COMMANDS[3]
 	if CTL then
 		CTL:SendAddonMessage("ALERT", COMM_NAME, commMessage, "GUILD")
@@ -816,15 +816,15 @@ end
 function Hardcore:Add(sender)
 		-- Display the death locally if alerts are not toggled off.
 		if Hardcore_Settings.notify then
-				local name, class, level, zone
-				for i = 1, GetNumGuildMembers() do
-						name, _, _, level, _, zone, _, _, _, _, class = GetGuildRosterInfo(i)
-						if name == sender then
-								local messageFormat = "%s the %s%s|r has died at level %d in %s"
-								local messageString = messageFormat:format(name:gsub("%-.*", ""), "|c" .. RAID_CLASS_COLORS[class].colorStr, class, level, zone)
-								Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
-						end
+			local name, class, level, zone
+			for i = 1, GetNumGuildMembers() do
+				name, _, _, level, _, zone, _, _, _, _, class = GetGuildRosterInfo(i)
+				if name == sender then
+					local messageFormat = "%s the %s%s|r has died at level %d in %s"
+					local messageString = messageFormat:format(name:gsub("%-.*", ""), "|c" .. RAID_CLASS_COLORS[class].colorStr, class, level, zone)
+					Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
 				end
+			end
 	end
 end
 
@@ -1113,8 +1113,8 @@ end
 
 -- Toggles death alerts on or off.
 function Hardcore_Toggle_Alerts()
-		Hardcore_Settings.notify = not Hardcore_Settings.notify
-		Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
+	Hardcore_Settings.notify = not Hardcore_Settings.notify
+	Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
 end
 
 function Hardcore_Deathlist_ScrollBar_Update()

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -23,18 +23,18 @@ local GRIEF_WARNING_SAME_FACTION = 1
 local GRIEF_WARNING_ENEMY_FACTION = 2
 local GRIEF_WARNING_BOTH_FACTIONS = 3
 local CLASSES = {
-    -- Classic:
-    [1] = "Warrior",
-    [2] = "Paladin",
-    [3] = "Hunter",
-    [4] = "Rogue",
-    [5] = "Priest",
-    [7] = "Shaman",
-    [8] = "Mage",
-    [9] = "Warlock",
-    [11] = "Druid",
-    -- WotLK:
-    [6] = "Death Knight"
+		-- Classic:
+		[1] = "Warrior",
+		[2] = "Paladin",
+		[3] = "Hunter",
+		[4] = "Rogue",
+		[5] = "Priest",
+		[7] = "Shaman",
+		[8] = "Mage",
+		[9] = "Warlock",
+		[11] = "Druid",
+		-- WotLK:
+		[6] = "Death Knight"
 }
 
 --[[ Global saved variables ]]--
@@ -473,9 +473,9 @@ function Hardcore:UNIT_SPELLCAST_SUCCEEDED(...)
 end
 
 function Hardcore:PLAYER_ENTERING_WORLD()
-    Hardcore_Frame:RegisterForDrag("LeftButton")
-    Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
-    
+		Hardcore_Frame:RegisterForDrag("LeftButton")
+		Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
+		
 	-- cache player name
 	PLAYER_NAME, _ = UnitName("player")
 	Hardcore:PrintBubbleHearthInfractions()
@@ -509,12 +509,12 @@ function Hardcore:PLAYER_DEAD()
 	end
 
 	-- Send message to guild
-    local playerGreet = GENDER_GREETING[UnitSex("player")]
-    local name = UnitName("player")
-    local _, _, classID = UnitClass("player")
-    local class = CLASSES[classID]
-    local level = UnitLevel("player")
-    local zone = C_Map.GetMapInfo(C_Map.GetBestMapForUnit("player")).name
+		local playerGreet = GENDER_GREETING[UnitSex("player")]
+		local name = UnitName("player")
+		local _, _, classID = UnitClass("player")
+		local class = CLASSES[classID]
+		local level = UnitLevel("player")
+		local zone = C_Map.GetMapInfo(C_Map.GetBestMapForUnit("player")).name
 	local messageFormat = "Our brave %s, %s the %s, has died at level %d in %s"
 	local messageString = messageFormat:format(playerGreet, name, class, level, zone)
 	if not (Last_Attack_Source == nil) then
@@ -523,7 +523,7 @@ function Hardcore:PLAYER_DEAD()
 	end
 	SendChatMessage(messageString, "GUILD")
 
-    -- Send addon message
+		-- Send addon message
 	local commMessage = COMM_COMMANDS[3]
 	if CTL then
 		CTL:SendAddonMessage("ALERT", COMM_NAME, commMessage, "GUILD")
@@ -814,17 +814,17 @@ function Hardcore:ShowAlertFrame(styleConfig, message)
 end
 
 function Hardcore:Add(sender)
-    -- Display the death locally if alerts are not toggled off.
-    if Hardcore_Settings.notify then
-        local name, class, level, zone
-        for i = 1, GetNumGuildMembers() do
-            name, _, _, level, _, zone, _, _, _, _, class = GetGuildRosterInfo(i)
-            if name == sender then
-                local messageFormat = "%s the %s%s|r has died at level %d in %s"
-                local messageString = messageFormat:format(name:gsub("%-.*", ""), "|c" .. RAID_CLASS_COLORS[class].colorStr, class, level, zone)
-                Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
-            end
-        end
+		-- Display the death locally if alerts are not toggled off.
+		if Hardcore_Settings.notify then
+				local name, class, level, zone
+				for i = 1, GetNumGuildMembers() do
+						name, _, _, level, _, zone, _, _, _, _, class = GetGuildRosterInfo(i)
+						if name == sender then
+								local messageFormat = "%s the %s%s|r has died at level %d in %s"
+								local messageString = messageFormat:format(name:gsub("%-.*", ""), "|c" .. RAID_CLASS_COLORS[class].colorStr, class, level, zone)
+								Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
+						end
+				end
 	end
 end
 
@@ -1113,8 +1113,8 @@ end
 
 -- Toggles death alerts on or off.
 function Hardcore_Toggle_Alerts()
-    Hardcore_Settings.notify = not Hardcore_Settings.notify
-    Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
+		Hardcore_Settings.notify = not Hardcore_Settings.notify
+		Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
 end
 
 function Hardcore_Deathlist_ScrollBar_Update()

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -22,6 +22,20 @@ local GRIEF_WARNING_OFF = 0
 local GRIEF_WARNING_SAME_FACTION = 1
 local GRIEF_WARNING_ENEMY_FACTION = 2
 local GRIEF_WARNING_BOTH_FACTIONS = 3
+local CLASSES = {
+    -- Classic:
+    [1] = "Warrior",
+    [2] = "Paladin",
+    [3] = "Hunter",
+    [4] = "Rogue",
+    [5] = "Priest",
+    [7] = "Shaman",
+    [8] = "Mage",
+    [9] = "Warlock",
+    [11] = "Druid",
+    -- WotLK:
+    [6] = "Death Knight"
+}
 
 --[[ Global saved variables ]]--
 Hardcore_Settings = {
@@ -194,7 +208,7 @@ local function SlashHandler(msg, editbox)
 		Hardcore:Print("Debugging set to " .. tostring(debug))
 	elseif cmd == "alerts" then
 		Hardcore_Toggle_Alerts()
-		if true == Hardcore_Settings.notify then
+		if Hardcore_Settings.notify then
 			Hardcore:Print("Alerts enabled")
 		else
 			Hardcore:Print("Alerts disabled")
@@ -479,8 +493,7 @@ function Hardcore:PLAYER_ALIVE()
 end
 
 function Hardcore:PLAYER_DEAD()
-
-	-- screenshot
+	-- Screenshot
 	C_Timer.After(PICTURE_DELAY, Screenshot)
 
 	-- Update deaths
@@ -491,29 +504,23 @@ function Hardcore:PLAYER_DEAD()
 		})
 	end
 
-	-- Get information
-	local playerId = UnitGUID("player")
-	local playerName, realmName = UnitName("player")
-	local localizedClass, englishClass = UnitClass("player")
-	local playerLevel = UnitLevel("player")
-	local mapId = C_Map.GetBestMapForUnit("player")
-	local mapName = C_Map.GetMapInfo(mapId).name
-	local playerGreet = GENDER_GREETING[UnitSex("player")]
-
 	-- Send message to guild
+    local playerGreet = GENDER_GREETING[UnitSex("player")]
+    local name = UnitName("player")
+    local _, _, classID = UnitClass("player")
+    local class = CLASSES[classID]
+    local level = UnitLevel("player")
+    local zone = C_Map.GetMapInfo(C_Map.GetBestMapForUnit("player")).name
 	local messageFormat = "Our brave %s, %s the %s, has died at level %d in %s"
-	local messageString = string.format(messageFormat, playerGreet, playerName, localizedClass, playerLevel, mapName)
+	local messageString = messageFormat:format(playerGreet, name, class, level, zone)
 	if not (Last_Attack_Source == nil) then
 		messageString = string.format("%s to a %s", messageString, Last_Attack_Source)
 		Last_Attack_Source = nil
 	end
-	SendChatMessage(messageString, "GUILD", nil, nil)
+	SendChatMessage(messageString, "GUILD")
 
-	-- Send add command to addon for this death
-	local deathData = string.format("%s%s%s%s%s%s%s%s%s%s%s", playerId, COMM_FIELD_DELIM, playerName, COMM_FIELD_DELIM,
-		localizedClass, COMM_FIELD_DELIM, playerLevel, COMM_FIELD_DELIM, mapId, COMM_FIELD_DELIM, time())
-
-	local commMessage = COMM_COMMANDS[2] .. COMM_COMMAND_DELIM .. deathData
+    -- Send addon message
+	local commMessage = COMM_COMMANDS[2]
 	if CTL then
 		CTL:SendAddonMessage("ALERT", COMM_NAME, commMessage, "GUILD")
 	end
@@ -714,7 +721,7 @@ function Hardcore:CHAT_MSG_ADDON(prefix, datastr, scope, sender)
 
 		-- Determine what command was sent
 		if command == COMM_COMMANDS[2] then
-			Hardcore:Add(data)
+			Hardcore:Add(sender)
 		elseif command == COMM_COMMANDS[1] then
 			Hardcore:ReceivePulse(data, sender)
 		else
@@ -801,20 +808,17 @@ function Hardcore:ShowAlertFrame(styleConfig, message)
 	end)
 end
 
-function Hardcore:Add(data)
-	-- Add the record if needed
-	if true == Hardcore:ValidateEntry(data) then
-		Hardcore:Debug("Adding new record " .. data)
-        
-		-- Display the death locally if alerts are not toggled off.
-        if Hardcore_Settings.notify then
-            local _, name, class_name, level, map_id, _ = string.split(COMM_FIELD_DELIM, data)
-            local class_color = Hardcore:GetClassColorText(class_name)
-            local map_name = C_Map.GetMapInfo(tonumber(map_id)).name
-            local messageFormat = "%s the %s%s|r has died at level %d in %s"
-            local messageString = string.format(messageFormat, name, class_color, class_name, level, map_name)
-
-            Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
+function Hardcore:Add(sender)
+    -- Display the death locally if alerts are not toggled off.
+    if Hardcore_Settings.notify then
+        local name, class, level, zone
+        for i = 1, GetNumGuildMembers() do
+            name, _, _, level, _, zone, _, _, _, _, class = GetGuildRosterInfo(i)
+            if name == sender then
+                local messageFormat = "%s the %s%s|r has died at level %d in %s"
+                local messageString = messageFormat:format(name:gsub("%-.*", ""), "|c" .. RAID_CLASS_COLORS[class].colorStr, class, level, zone)
+                Hardcore:ShowAlertFrame(ALERT_STYLES.death, messageString)
+            end
         end
 	end
 end
@@ -974,45 +978,6 @@ function Hardcore:GetClassColorText(classname)
 
 	Hardcore:Debug("ERROR: classname not found")
 	return "|c00c41f3b" -- Red
-end
-
-function Hardcore:ValidateEntry(data)
-	local playerId, name, classname, level, mapId, tod = string.split(COMM_FIELD_DELIM, data)
-
-	if nil == playerId then
-		Hardcore:Debug("ERROR: 'playerId' field is nil")
-		return false
-	end
-
-	if nil == name then
-		Hardcore:Debug("ERROR: 'name' field is nil")
-		return false
-	end
-
-	if nil == classname then
-		Hardcore:Debug("ERROR: 'class' field is nil")
-		return false
-	end
-
-	if nil == level then
-		Hardcore:Debug("ERROR: 'level' field is nil")
-		return false
-	elseif 1 == tonumber(level) then
-		Hardcore:Debug("WARN: Ignoring level 1 death")
-		return false
-	end
-
-	if nil == mapId then
-		Hardcore:Debug("ERROR: 'mapId' field is nil")
-		return false
-	end
-
-	if nil == tod then
-		Hardcore:Debug("ERROR: 'tod' field is nil")
-		return false
-	end
-
-	return true
 end
 
 --[[ UI Methods ]]--
@@ -1181,12 +1146,7 @@ function Hardcore_Deathlist_ScrollBar_Update()
 end
 
 function Hardcore:RecordReminder()
-	if not Hardcore_Settings.notify then
-		return
-	end
-
 	Hardcore:ShowAlertFrame(ALERT_STYLES.hc_enabled, "Character Activity is Being Monitored")
-
 end
 
 ----------------------------------------------------------------------

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -25,11 +25,10 @@ local GRIEF_WARNING_BOTH_FACTIONS = 3
 
 --[[ Global saved variables ]]--
 Hardcore_Settings = {
-	notify = true,
 	level_list = {},
 }
 
-Hardcore_Settings.shouldAlertDeaths = Hardcore_Settings.shouldAlertDeaths or true -- Will display death alerts by default.
+Hardcore_Settings.notify = Hardcore_Settings.notify or true -- Will display death alerts by default.
 
 --[[ Character saved variables ]]--
 Hardcore_Character = {
@@ -193,12 +192,12 @@ local function SlashHandler(msg, editbox)
 	elseif cmd == "debug" then
 		debug = not debug
 		Hardcore:Print("Debugging set to " .. tostring(debug))
-	elseif cmd == "notify" then
-		Hardcore_Settings.notify = not Hardcore_Settings.notify
+	elseif cmd == "alerts" then
+		Hardcore_Toggle_Alerts()
 		if true == Hardcore_Settings.notify then
-			Hardcore:Print("Notification enabled")
+			Hardcore:Print("Alerts enabled")
 		else
-			Hardcore:Print("Notification disabled")
+			Hardcore:Print("Alerts disabled")
 		end
 	elseif cmd == "griefalert" then
 		local grief_alert_option = ""
@@ -457,7 +456,7 @@ end
 
 function Hardcore:PLAYER_ENTERING_WORLD()
     Hardcore_Frame:RegisterForDrag("LeftButton")
-    Hardcore_Alerts_Button:SetText(Hardcore_Settings.shouldAlertDeaths and "Disable alerts" or "Enable alerts")
+    Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
     
 	-- cache player name
 	PLAYER_NAME, _ = UnitName("player")
@@ -808,7 +807,7 @@ function Hardcore:Add(data)
 		Hardcore:Debug("Adding new record " .. data)
         
 		-- Display the death locally if alerts are not toggled off.
-        if Hardcore_Settings.shouldAlertDeaths then
+        if Hardcore_Settings.notify then
             local _, name, class_name, level, map_id, _ = string.split(COMM_FIELD_DELIM, data)
             local class_color = Hardcore:GetClassColorText(class_name)
             local map_name = C_Map.GetMapInfo(tonumber(map_id)).name
@@ -1144,8 +1143,8 @@ end
 
 -- Toggles death alerts on or off.
 function Hardcore_Toggle_Alerts()
-    Hardcore_Settings.shouldAlertDeaths = not Hardcore_Settings.shouldAlertDeaths
-    Hardcore_Alerts_Button:SetText(Hardcore_Settings.shouldAlertDeaths and "Disable alerts" or "Enable alerts")
+    Hardcore_Settings.notify = not Hardcore_Settings.notify
+    Hardcore_Alerts_Button:SetText(Hardcore_Settings.notify and "Disable alerts" or "Enable alerts")
 end
 
 function Hardcore_Deathlist_ScrollBar_Update()
@@ -1182,7 +1181,7 @@ function Hardcore_Deathlist_ScrollBar_Update()
 end
 
 function Hardcore:RecordReminder()
-	if Hardcore_Settings.notify == false then
+	if not Hardcore_Settings.notify then
 		return
 	end
 

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -85,7 +85,11 @@ local COMM_BATCH_SIZE = 4
 local COMM_COMMAND_DELIM = "$"
 local COMM_FIELD_DELIM = "|"
 local COMM_RECORD_DELIM = "^"
-local COMM_COMMANDS = {"PULSE", "ADD", nil}
+local COMM_COMMANDS = {
+	"PULSE",
+	"ADD", -- depreciated, we can only handle receiving
+	"DEAD" -- new death command
+}
 
 -- stuff
 local PLAYER_NAME, _ = nil
@@ -520,7 +524,7 @@ function Hardcore:PLAYER_DEAD()
 	SendChatMessage(messageString, "GUILD")
 
     -- Send addon message
-	local commMessage = COMM_COMMANDS[2]
+	local commMessage = COMM_COMMANDS[3]
 	if CTL then
 		CTL:SendAddonMessage("ALERT", COMM_NAME, commMessage, "GUILD")
 	end
@@ -720,7 +724,8 @@ function Hardcore:CHAT_MSG_ADDON(prefix, datastr, scope, sender)
 		local command, data = string.split(COMM_COMMAND_DELIM, datastr)
 
 		-- Determine what command was sent
-		if command == COMM_COMMANDS[2] then
+		-- COMM_COMMANDS[2] is deprecated, but its backwards compatible so we still can handle
+		if command == COMM_COMMANDS[2] or command == COMM_COMMANDS[3] then
 			Hardcore:Add(sender)
 		elseif command == COMM_COMMANDS[1] then
 			Hardcore:ReceivePulse(data, sender)

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -40,9 +40,8 @@ local CLASSES = {
 --[[ Global saved variables ]]--
 Hardcore_Settings = {
 	level_list = {},
+	notify = true,
 }
-
-Hardcore_Settings.notify = Hardcore_Settings.notify or true -- Will display death alerts by default.
 
 --[[ Character saved variables ]]--
 Hardcore_Character = {
@@ -291,7 +290,7 @@ local function SlashHandler(msg, editbox)
 	else
 		-- If not handled above, display some sort of help message
 		Hardcore:Print("|cff00ff00Syntax:|r/hardcore [command] [options]")
-		Hardcore:Print("|cff00ff00Commands:|rshow deaths levels enable disable griefalert")
+		Hardcore:Print("|cff00ff00Commands:|rshow deaths levels enable disable griefalert alerts")
 	end
 end
 

--- a/Hardcore.xml
+++ b/Hardcore.xml
@@ -249,14 +249,14 @@
 			</Anchors>
 		  </Button>
 
-            <Button name="Hardcore_Alerts_Button" inherits="UIPanelButtonTemplate" text="Disable alerts">
+			<Button name="Hardcore_Alerts_Button" inherits="UIPanelButtonTemplate" text="Disable alerts">
 				<Size x="120" y="37" />
 				<Anchors>
 					<Anchor point="TOPLEFT" x="520" y="-20" />
 				</Anchors>
 				<Scripts>
 					<OnClick>
-                        Hardcore_Toggle_Alerts()
+						Hardcore_Toggle_Alerts()
 					</OnClick>
 				</Scripts>
 			</Button>

--- a/Hardcore.xml
+++ b/Hardcore.xml
@@ -60,7 +60,7 @@
 		</Layers>
   </Frame>
 
-  <Frame name="Hardcore_Frame" parent="UIParent" hidden="true" toplevel="true" movable="true" enableMouse="true" inherits="BackdropTemplate">>
+  <Frame name="Hardcore_Frame" parent="UIParent" hidden="true" toplevel="true" clampedToScreen="true" enableMouse="true" movable="true" inherits="BackdropTemplate">
 		<Size x="700" y="500" />
 		<Anchors>
 			<Anchor point="TOPLEFT" relativeTo="UIParent" relativePoint="TOPLEFT" x="336" y="-35" />
@@ -94,6 +94,12 @@
 			</Layer>
 		</Layers>
 		<Scripts>
+          <OnDragStart>
+            self:StartMoving()
+          </OnDragStart>
+          <OnDragStop>
+            self:StopMovingOrSizing()
+          </OnDragStop>
 		  <OnLoad>
 			tinsert(UISpecialFrames, self:GetName());
 		  </OnLoad>
@@ -243,6 +249,17 @@
 			</Anchors>
 		  </Button>
 
+            <Button name="Hardcore_Alerts_Button" inherits="UIPanelButtonTemplate" text="Disable alerts">
+				<Size x="120" y="37" />
+				<Anchors>
+					<Anchor point="TOPLEFT" x="520" y="-20" />
+				</Anchors>
+				<Scripts>
+					<OnClick>
+                        Hardcore_Toggle_Alerts()
+					</OnClick>
+				</Scripts>
+			</Button>
 			<Button name="Hardcore_Name_Sort" inherits="OptionsButtonTemplate" text="Name">
 				<Size x="100" y="20" />
 				<Anchors>


### PR DESCRIPTION
Includes commits from @cloudbells:

- Made the frame draggable.
- Added a toggle for showing death alerts.
- Removed the possibility to send custom addon messages that would be displayed on every addon user's screen (griefable by sending rude words)

I added is deprecation of the old command (so it doesn't break old versions) and support for the new command