### PR TITLE
basic interface options support

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -46,6 +46,7 @@ Hardcore_Settings = {
 	alert_frame_x_offset = 0,
 	alert_frame_y_offset = -150,
 	alert_frame_scale = 0.7,
+	show_minimap_mailbox_icon = false,
 }
 
 --[[ Character saved variables ]]--
@@ -385,6 +386,31 @@ local options = {
 				},
 			},
 		},
+		miscellaneous_header = {
+			type = "group",
+			name = "Miscellaneous",
+			order = 9,
+			inline = true,
+			args = {
+				show_minimap_icon = {
+					type = "toggle",
+					name = "Show minimap mail icon",
+					desc = "Show minimap mail icon",
+					get = (function()return Hardcore_Settings.show_minimap_mailbox_icon end),
+					set = function()
+						Hardcore_Settings.show_minimap_mailbox_icon = not Hardcore_Settings.show_minimap_mailbox_icon
+						if Hardcore_Settings.show_minimap_mailbox_icon == true then
+							MiniMapMailIcon:Show()
+							MiniMapMailBorder:Show()
+						else
+							MiniMapMailIcon:Hide()
+							MiniMapMailBorder:Hide()
+						end
+					end,
+					order = 10,
+				},
+			},
+		},
 		apply_defaults = {
 			type = "execute",
 			name = "Defaults",
@@ -397,9 +423,10 @@ local options = {
 				Hardcore_Settings.alert_frame_x_offset = 0
 				Hardcore_Settings.alert_frame_y_offset = -150
 				Hardcore_Settings.alert_frame_scale = .7
+				Hardcore_Settings.show_minimap_mailbox_icon = false
 				Hardcore:ApplyAlertFrameSettings()
 			end,
-			order = 9,
+			order = 11,
 		},
 	},
 }
@@ -686,6 +713,11 @@ function Hardcore:PLAYER_ENTERING_WORLD()
 	PLAYER_NAME, _ = UnitName("player")
 	Hardcore:PrintBubbleHearthInfractions()
 	Hardcore:Monitor("Monitoring malicious users enabled.")
+
+	if Hardcore_Settings.show_minimap_mailbox_icon == false then
+		MiniMapMailIcon:Hide()
+		MiniMapMailBorder:Hide()
+	end
 
 	-- initialize addon communication
 	if (not C_ChatInfo.IsAddonMessagePrefixRegistered(COMM_NAME)) then

--- a/Libs/AceConfig-3.0/AceConfig-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfig-3.0.lua
@@ -1,0 +1,58 @@
+--- AceConfig-3.0 wrapper library.
+-- Provides an API to register an options table with the config registry,
+-- as well as associate it with a slash command.
+-- @class file
+-- @name AceConfig-3.0
+-- @release $Id: AceConfig-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
+
+--[[
+AceConfig-3.0
+
+Very light wrapper library that combines all the AceConfig subcomponents into one more easily used whole.
+
+]]
+
+local cfgreg = LibStub("AceConfigRegistry-3.0")
+local cfgcmd = LibStub("AceConfigCmd-3.0")
+
+local MAJOR, MINOR = "AceConfig-3.0", 3
+local AceConfig = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceConfig then return end
+
+--TODO: local cfgdlg = LibStub("AceConfigDialog-3.0", true)
+--TODO: local cfgdrp = LibStub("AceConfigDropdown-3.0", true)
+
+-- Lua APIs
+local pcall, error, type, pairs = pcall, error, type, pairs
+
+-- -------------------------------------------------------------------
+-- :RegisterOptionsTable(appName, options, slashcmd, persist)
+--
+-- - appName - (string) application name
+-- - options - table or function ref, see AceConfigRegistry
+-- - slashcmd - slash command (string) or table with commands, or nil to NOT create a slash command
+
+--- Register a option table with the AceConfig registry.
+-- You can supply a slash command (or a table of slash commands) to register with AceConfigCmd directly.
+-- @paramsig appName, options [, slashcmd]
+-- @param appName The application name for the config table.
+-- @param options The option table (or a function to generate one on demand).  http://www.wowace.com/addons/ace3/pages/ace-config-3-0-options-tables/
+-- @param slashcmd A slash command to register for the option table, or a table of slash commands.
+-- @usage
+-- local AceConfig = LibStub("AceConfig-3.0")
+-- AceConfig:RegisterOptionsTable("MyAddon", myOptions, {"/myslash", "/my"})
+function AceConfig:RegisterOptionsTable(appName, options, slashcmd)
+	local ok,msg = pcall(cfgreg.RegisterOptionsTable, self, appName, options)
+	if not ok then error(msg, 2) end
+
+	if slashcmd then
+		if type(slashcmd) == "table" then
+			for _,cmd in pairs(slashcmd) do
+				cfgcmd:CreateChatCommand(cmd, appName)
+			end
+		else
+			cfgcmd:CreateChatCommand(slashcmd, appName)
+		end
+	end
+end

--- a/Libs/AceConfig-3.0/AceConfig-3.0.xml
+++ b/Libs/AceConfig-3.0/AceConfig-3.0.xml
@@ -1,0 +1,8 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Include file="AceConfigRegistry-3.0\AceConfigRegistry-3.0.xml"/>
+	<Include file="AceConfigCmd-3.0\AceConfigCmd-3.0.xml"/>
+	<Include file="AceConfigDialog-3.0\AceConfigDialog-3.0.xml"/>
+	<!--<Include file="AceConfigDropdown-3.0\AceConfigDropdown-3.0.xml"/>-->
+	<Script file="AceConfig-3.0.lua"/>
+</Ui>

--- a/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.lua
@@ -1,0 +1,794 @@
+--- AceConfigCmd-3.0 handles access to an options table through the "command line" interface via the ChatFrames.
+-- @class file
+-- @name AceConfigCmd-3.0
+-- @release $Id: AceConfigCmd-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
+
+--[[
+AceConfigCmd-3.0
+
+Handles commandline optionstable access
+
+REQUIRES: AceConsole-3.0 for command registration (loaded on demand)
+
+]]
+
+-- TODO: plugin args
+
+local cfgreg = LibStub("AceConfigRegistry-3.0")
+
+local MAJOR, MINOR = "AceConfigCmd-3.0", 14
+local AceConfigCmd = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceConfigCmd then return end
+
+AceConfigCmd.commands = AceConfigCmd.commands or {}
+local commands = AceConfigCmd.commands
+
+local AceConsole -- LoD
+local AceConsoleName = "AceConsole-3.0"
+
+-- Lua APIs
+local strsub, strsplit, strlower, strmatch, strtrim = string.sub, string.split, string.lower, string.match, string.trim
+local format, tonumber, tostring = string.format, tonumber, tostring
+local tsort, tinsert = table.sort, table.insert
+local select, pairs, next, type = select, pairs, next, type
+local error, assert = error, assert
+
+-- WoW APIs
+local _G = _G
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: LibStub, SELECTED_CHAT_FRAME, DEFAULT_CHAT_FRAME
+
+
+local L = setmetatable({}, {	-- TODO: replace with proper locale
+	__index = function(self,k) return k end
+})
+
+
+
+local function print(msg)
+	(SELECTED_CHAT_FRAME or DEFAULT_CHAT_FRAME):AddMessage(msg)
+end
+
+-- constants used by getparam() calls below
+
+local handlertypes = {["table"]=true}
+local handlermsg = "expected a table"
+
+local functypes = {["function"]=true, ["string"]=true}
+local funcmsg = "expected function or member name"
+
+
+-- pickfirstset() - picks the first non-nil value and returns it
+
+local function pickfirstset(...)
+	for i=1,select("#",...) do
+		if select(i,...)~=nil then
+			return select(i,...)
+		end
+	end
+end
+
+
+-- err() - produce real error() regarding malformed options tables etc
+
+local function err(info,inputpos,msg )
+	local cmdstr=" "..strsub(info.input, 1, inputpos-1)
+	error(MAJOR..": /" ..info[0] ..cmdstr ..": "..(msg or "malformed options table"), 2)
+end
+
+
+-- usererr() - produce chatframe message regarding bad slash syntax etc
+
+local function usererr(info,inputpos,msg )
+	local cmdstr=strsub(info.input, 1, inputpos-1);
+	print("/" ..info[0] .. " "..cmdstr ..": "..(msg or "malformed options table"))
+end
+
+
+-- callmethod() - call a given named method (e.g. "get", "set") with given arguments
+
+local function callmethod(info, inputpos, tab, methodtype, ...)
+	local method = info[methodtype]
+	if not method then
+		err(info, inputpos, "'"..methodtype.."': not set")
+	end
+
+	info.arg = tab.arg
+	info.option = tab
+	info.type = tab.type
+
+	if type(method)=="function" then
+		return method(info, ...)
+	elseif type(method)=="string" then
+		if type(info.handler[method])~="function" then
+			err(info, inputpos, "'"..methodtype.."': '"..method.."' is not a member function of "..tostring(info.handler))
+		end
+		return info.handler[method](info.handler, info, ...)
+	else
+		assert(false)	-- type should have already been checked on read
+	end
+end
+
+-- callfunction() - call a given named function (e.g. "name", "desc") with given arguments
+
+local function callfunction(info, tab, methodtype, ...)
+	local method = tab[methodtype]
+
+	info.arg = tab.arg
+	info.option = tab
+	info.type = tab.type
+
+	if type(method)=="function" then
+		return method(info, ...)
+	else
+		assert(false) -- type should have already been checked on read
+	end
+end
+
+-- do_final() - do the final step (set/execute) along with validation and confirmation
+
+local function do_final(info, inputpos, tab, methodtype, ...)
+	if info.validate then
+		local res = callmethod(info,inputpos,tab,"validate",...)
+		if type(res)=="string" then
+			usererr(info, inputpos, "'"..strsub(info.input, inputpos).."' - "..res)
+			return
+		end
+	end
+	-- console ignores .confirm
+
+	callmethod(info,inputpos,tab,methodtype, ...)
+end
+
+
+-- getparam() - used by handle() to retreive and store "handler", "get", "set", etc
+
+local function getparam(info, inputpos, tab, depth, paramname, types, errormsg)
+	local old,oldat = info[paramname], info[paramname.."_at"]
+	local val=tab[paramname]
+	if val~=nil then
+		if val==false then
+			val=nil
+		elseif not types[type(val)] then
+			err(info, inputpos, "'" .. paramname.. "' - "..errormsg)
+		end
+		info[paramname] = val
+		info[paramname.."_at"] = depth
+	end
+	return old,oldat
+end
+
+
+-- iterateargs(tab) - custom iterator that iterates both t.args and t.plugins.*
+local dummytable={}
+
+local function iterateargs(tab)
+	if not tab.plugins then
+		return pairs(tab.args)
+	end
+
+	local argtabkey,argtab=next(tab.plugins)
+	local v
+
+	return function(_, k)
+		while argtab do
+			k,v = next(argtab, k)
+			if k then return k,v end
+			if argtab==tab.args then
+				argtab=nil
+			else
+				argtabkey,argtab = next(tab.plugins, argtabkey)
+				if not argtabkey then
+					argtab=tab.args
+				end
+			end
+		end
+	end
+end
+
+local function checkhidden(info, inputpos, tab)
+	if tab.cmdHidden~=nil then
+		return tab.cmdHidden
+	end
+	local hidden = tab.hidden
+	if type(hidden) == "function" or type(hidden) == "string" then
+		info.hidden = hidden
+		hidden = callmethod(info, inputpos, tab, 'hidden')
+		info.hidden = nil
+	end
+	return hidden
+end
+
+local function showhelp(info, inputpos, tab, depth, noHead)
+	if not noHead then
+		print("|cff33ff99"..info.appName.."|r: Arguments to |cffffff78/"..info[0].."|r "..strsub(info.input,1,inputpos-1)..":")
+	end
+
+	local sortTbl = {}	-- [1..n]=name
+	local refTbl = {}   -- [name]=tableref
+
+	for k,v in iterateargs(tab) do
+		if not refTbl[k] then	-- a plugin overriding something in .args
+			tinsert(sortTbl, k)
+			refTbl[k] = v
+		end
+	end
+
+	tsort(sortTbl, function(one, two)
+		local o1 = refTbl[one].order or 100
+		local o2 = refTbl[two].order or 100
+		if type(o1) == "function" or type(o1) == "string" then
+			info.order = o1
+			info[#info+1] = one
+			o1 = callmethod(info, inputpos, refTbl[one], "order")
+			info[#info] = nil
+			info.order = nil
+		end
+		if type(o2) == "function" or type(o1) == "string" then
+			info.order = o2
+			info[#info+1] = two
+			o2 = callmethod(info, inputpos, refTbl[two], "order")
+			info[#info] = nil
+			info.order = nil
+		end
+		if o1<0 and o2<0 then return o1<o2 end
+		if o2<0 then return true end
+		if o1<0 then return false end
+		if o1==o2 then return tostring(one)<tostring(two) end   -- compare names
+		return o1<o2
+	end)
+
+	for i = 1, #sortTbl do
+		local k = sortTbl[i]
+		local v = refTbl[k]
+		if not checkhidden(info, inputpos, v) then
+			if v.type ~= "description" and v.type ~= "header" then
+				-- recursively show all inline groups
+				local name, desc = v.name, v.desc
+				if type(name) == "function" then
+					name = callfunction(info, v, 'name')
+				end
+				if type(desc) == "function" then
+					desc = callfunction(info, v, 'desc')
+				end
+				if v.type == "group" and pickfirstset(v.cmdInline, v.inline, false) then
+					print("  "..(desc or name)..":")
+					local oldhandler,oldhandler_at = getparam(info, inputpos, v, depth, "handler", handlertypes, handlermsg)
+					showhelp(info, inputpos, v, depth, true)
+					info.handler,info.handler_at = oldhandler,oldhandler_at
+				else
+					local key = k:gsub(" ", "_")
+					print("  |cffffff78"..key.."|r - "..(desc or name or ""))
+				end
+			end
+		end
+	end
+end
+
+
+local function keybindingValidateFunc(text)
+	if text == nil or text == "NONE" then
+		return nil
+	end
+	text = text:upper()
+	local shift, ctrl, alt
+	local modifier
+	while true do
+		if text == "-" then
+			break
+		end
+		modifier, text = strsplit('-', text, 2)
+		if text then
+			if modifier ~= "SHIFT" and modifier ~= "CTRL" and modifier ~= "ALT" then
+				return false
+			end
+			if modifier == "SHIFT" then
+				if shift then
+					return false
+				end
+				shift = true
+			end
+			if modifier == "CTRL" then
+				if ctrl then
+					return false
+				end
+				ctrl = true
+			end
+			if modifier == "ALT" then
+				if alt then
+					return false
+				end
+				alt = true
+			end
+		else
+			text = modifier
+			break
+		end
+	end
+	if text == "" then
+		return false
+	end
+	if not text:find("^F%d+$") and text ~= "CAPSLOCK" and text:len() ~= 1 and (text:byte() < 128 or text:len() > 4) and not _G["KEY_" .. text] then
+		return false
+	end
+	local s = text
+	if shift then
+		s = "SHIFT-" .. s
+	end
+	if ctrl then
+		s = "CTRL-" .. s
+	end
+	if alt then
+		s = "ALT-" .. s
+	end
+	return s
+end
+
+-- handle() - selfrecursing function that processes input->optiontable
+-- - depth - starts at 0
+-- - retfalse - return false rather than produce error if a match is not found (used by inlined groups)
+
+local function handle(info, inputpos, tab, depth, retfalse)
+
+	if not(type(tab)=="table" and type(tab.type)=="string") then err(info,inputpos) end
+
+	-------------------------------------------------------------------
+	-- Grab hold of handler,set,get,func,etc if set (and remember old ones)
+	-- Note that we do NOT validate if method names are correct at this stage,
+	-- the handler may change before they're actually used!
+
+	local oldhandler,oldhandler_at = getparam(info,inputpos,tab,depth,"handler",handlertypes,handlermsg)
+	local oldset,oldset_at = getparam(info,inputpos,tab,depth,"set",functypes,funcmsg)
+	local oldget,oldget_at = getparam(info,inputpos,tab,depth,"get",functypes,funcmsg)
+	local oldfunc,oldfunc_at = getparam(info,inputpos,tab,depth,"func",functypes,funcmsg)
+	local oldvalidate,oldvalidate_at = getparam(info,inputpos,tab,depth,"validate",functypes,funcmsg)
+	--local oldconfirm,oldconfirm_at = getparam(info,inputpos,tab,depth,"confirm",functypes,funcmsg)
+
+	-------------------------------------------------------------------
+	-- Act according to .type of this table
+
+	if tab.type=="group" then
+		------------ group --------------------------------------------
+
+		if type(tab.args)~="table" then err(info, inputpos) end
+		if tab.plugins and type(tab.plugins)~="table" then err(info,inputpos) end
+
+		-- grab next arg from input
+		local _,nextpos,arg = (info.input):find(" *([^ ]+) *", inputpos)
+		if not arg then
+			showhelp(info, inputpos, tab, depth)
+			return
+		end
+		nextpos=nextpos+1
+
+		-- loop .args and try to find a key with a matching name
+		for k,v in iterateargs(tab) do
+			if not(type(k)=="string" and type(v)=="table" and type(v.type)=="string") then err(info,inputpos, "options table child '"..tostring(k).."' is malformed") end
+
+			-- is this child an inline group? if so, traverse into it
+			if v.type=="group" and pickfirstset(v.cmdInline, v.inline, false) then
+				info[depth+1] = k
+				if handle(info, inputpos, v, depth+1, true)==false then
+					info[depth+1] = nil
+					-- wasn't found in there, but that's ok, we just keep looking down here
+				else
+					return	-- done, name was found in inline group
+				end
+			-- matching name and not a inline group
+			elseif strlower(arg)==strlower(k:gsub(" ", "_")) then
+				info[depth+1] = k
+				return handle(info,nextpos,v,depth+1)
+			end
+		end
+
+		-- no match
+		if retfalse then
+			-- restore old infotable members and return false to indicate failure
+			info.handler,info.handler_at = oldhandler,oldhandler_at
+			info.set,info.set_at = oldset,oldset_at
+			info.get,info.get_at = oldget,oldget_at
+			info.func,info.func_at = oldfunc,oldfunc_at
+			info.validate,info.validate_at = oldvalidate,oldvalidate_at
+			--info.confirm,info.confirm_at = oldconfirm,oldconfirm_at
+			return false
+		end
+
+		-- couldn't find the command, display error
+		usererr(info, inputpos, "'"..arg.."' - " .. L["unknown argument"])
+		return
+	end
+
+	local str = strsub(info.input,inputpos);
+
+	if tab.type=="execute" then
+		------------ execute --------------------------------------------
+		do_final(info, inputpos, tab, "func")
+
+
+
+	elseif tab.type=="input" then
+		------------ input --------------------------------------------
+
+		local res = true
+		if tab.pattern then
+			if not(type(tab.pattern)=="string") then err(info, inputpos, "'pattern' - expected a string") end
+			if not strmatch(str, tab.pattern) then
+				usererr(info, inputpos, "'"..str.."' - " .. L["invalid input"])
+				return
+			end
+		end
+
+		do_final(info, inputpos, tab, "set", str)
+
+
+
+	elseif tab.type=="toggle" then
+		------------ toggle --------------------------------------------
+		local b
+		local str = strtrim(strlower(str))
+		if str=="" then
+			b = callmethod(info, inputpos, tab, "get")
+
+			if tab.tristate then
+				--cycle in true, nil, false order
+				if b then
+					b = nil
+				elseif b == nil then
+					b = false
+				else
+					b = true
+				end
+			else
+				b = not b
+			end
+
+		elseif str==L["on"] then
+			b = true
+		elseif str==L["off"] then
+			b = false
+		elseif tab.tristate and str==L["default"] then
+			b = nil
+		else
+			if tab.tristate then
+				usererr(info, inputpos, format(L["'%s' - expected 'on', 'off' or 'default', or no argument to toggle."], str))
+			else
+				usererr(info, inputpos, format(L["'%s' - expected 'on' or 'off', or no argument to toggle."], str))
+			end
+			return
+		end
+
+		do_final(info, inputpos, tab, "set", b)
+
+
+	elseif tab.type=="range" then
+		------------ range --------------------------------------------
+		local val = tonumber(str)
+		if not val then
+			usererr(info, inputpos, "'"..str.."' - "..L["expected number"])
+			return
+		end
+		if type(info.step)=="number" then
+			val = val- (val % info.step)
+		end
+		if type(info.min)=="number" and val<info.min then
+			usererr(info, inputpos, val.." - "..format(L["must be equal to or higher than %s"], tostring(info.min)) )
+			return
+		end
+		if type(info.max)=="number" and val>info.max then
+			usererr(info, inputpos, val.." - "..format(L["must be equal to or lower than %s"], tostring(info.max)) )
+			return
+		end
+
+		do_final(info, inputpos, tab, "set", val)
+
+
+	elseif tab.type=="select" then
+		------------ select ------------------------------------
+		local str = strtrim(strlower(str))
+
+		local values = tab.values
+		if type(values) == "function" or type(values) == "string" then
+			info.values = values
+			values = callmethod(info, inputpos, tab, "values")
+			info.values = nil
+		end
+
+		if str == "" then
+			local b = callmethod(info, inputpos, tab, "get")
+			local fmt = "|cffffff78- [%s]|r %s"
+			local fmt_sel = "|cffffff78- [%s]|r %s |cffff0000*|r"
+			print(L["Options for |cffffff78"..info[#info].."|r:"])
+			for k, v in pairs(values) do
+				if b == k then
+					print(fmt_sel:format(k, v))
+				else
+					print(fmt:format(k, v))
+				end
+			end
+			return
+		end
+
+		local ok
+		for k,v in pairs(values) do
+			if strlower(k)==str then
+				str = k	-- overwrite with key (in case of case mismatches)
+				ok = true
+				break
+			end
+		end
+		if not ok then
+			usererr(info, inputpos, "'"..str.."' - "..L["unknown selection"])
+			return
+		end
+
+		do_final(info, inputpos, tab, "set", str)
+
+	elseif tab.type=="multiselect" then
+		------------ multiselect -------------------------------------------
+		local str = strtrim(strlower(str))
+
+		local values = tab.values
+		if type(values) == "function" or type(values) == "string" then
+			info.values = values
+			values = callmethod(info, inputpos, tab, "values")
+			info.values = nil
+		end
+
+		if str == "" then
+			local fmt = "|cffffff78- [%s]|r %s"
+			local fmt_sel = "|cffffff78- [%s]|r %s |cffff0000*|r"
+			print(L["Options for |cffffff78"..info[#info].."|r (multiple possible):"])
+			for k, v in pairs(values) do
+				if callmethod(info, inputpos, tab, "get", k) then
+					print(fmt_sel:format(k, v))
+				else
+					print(fmt:format(k, v))
+				end
+			end
+			return
+		end
+
+		--build a table of the selections, checking that they exist
+		--parse for =on =off =default in the process
+		--table will be key = true for options that should toggle, key = [on|off|default] for options to be set
+		local sels = {}
+		for v in str:gmatch("[^ ]+") do
+			--parse option=on etc
+			local opt, val = v:match('(.+)=(.+)')
+			--get option if toggling
+			if not opt then
+				opt = v
+			end
+
+			--check that the opt is valid
+			local ok
+			for k,v in pairs(values) do
+				if strlower(k)==opt then
+					opt = k	-- overwrite with key (in case of case mismatches)
+					ok = true
+					break
+				end
+			end
+
+			if not ok then
+				usererr(info, inputpos, "'"..opt.."' - "..L["unknown selection"])
+				return
+			end
+
+			--check that if val was supplied it is valid
+			if val then
+				if val == L["on"] or val == L["off"] or (tab.tristate and val == L["default"]) then
+					--val is valid insert it
+					sels[opt] = val
+				else
+					if tab.tristate then
+						usererr(info, inputpos, format(L["'%s' '%s' - expected 'on', 'off' or 'default', or no argument to toggle."], v, val))
+					else
+						usererr(info, inputpos, format(L["'%s' '%s' - expected 'on' or 'off', or no argument to toggle."], v, val))
+					end
+					return
+				end
+			else
+				-- no val supplied, toggle
+				sels[opt] = true
+			end
+		end
+
+		for opt, val in pairs(sels) do
+			local newval
+
+			if (val == true) then
+				--toggle the option
+				local b = callmethod(info, inputpos, tab, "get", opt)
+
+				if tab.tristate then
+					--cycle in true, nil, false order
+					if b then
+						b = nil
+					elseif b == nil then
+						b = false
+					else
+						b = true
+					end
+				else
+					b = not b
+				end
+				newval = b
+			else
+				--set the option as specified
+				if val==L["on"] then
+					newval = true
+				elseif val==L["off"] then
+					newval = false
+				elseif val==L["default"] then
+					newval = nil
+				end
+			end
+
+			do_final(info, inputpos, tab, "set", opt, newval)
+		end
+
+
+	elseif tab.type=="color" then
+		------------ color --------------------------------------------
+		local str = strtrim(strlower(str))
+		if str == "" then
+			--TODO: Show current value
+			return
+		end
+
+		local r, g, b, a
+
+		local hasAlpha = tab.hasAlpha
+		if type(hasAlpha) == "function" or type(hasAlpha) == "string" then
+			info.hasAlpha = hasAlpha
+			hasAlpha = callmethod(info, inputpos, tab, 'hasAlpha')
+			info.hasAlpha = nil
+		end
+
+		if hasAlpha then
+			if str:len() == 8 and str:find("^%x*$")  then
+				--parse a hex string
+				r,g,b,a = tonumber(str:sub(1, 2), 16) / 255, tonumber(str:sub(3, 4), 16) / 255, tonumber(str:sub(5, 6), 16) / 255, tonumber(str:sub(7, 8), 16) / 255
+			else
+				--parse seperate values
+				r,g,b,a = str:match("^([%d%.]+) ([%d%.]+) ([%d%.]+) ([%d%.]+)$")
+				r,g,b,a = tonumber(r), tonumber(g), tonumber(b), tonumber(a)
+			end
+			if not (r and g and b and a) then
+				usererr(info, inputpos, format(L["'%s' - expected 'RRGGBBAA' or 'r g b a'."], str))
+				return
+			end
+
+			if r >= 0.0 and r <= 1.0 and g >= 0.0 and g <= 1.0 and b >= 0.0 and b <= 1.0 and a >= 0.0 and a <= 1.0 then
+				--values are valid
+			elseif r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and b <= 255 and a >= 0 and a <= 255 then
+				--values are valid 0..255, convert to 0..1
+				r = r / 255
+				g = g / 255
+				b = b / 255
+				a = a / 255
+			else
+				--values are invalid
+				usererr(info, inputpos, format(L["'%s' - values must all be either in the range 0..1 or 0..255."], str))
+			end
+		else
+			a = 1.0
+			if str:len() == 6 and str:find("^%x*$") then
+				--parse a hex string
+				r,g,b = tonumber(str:sub(1, 2), 16) / 255, tonumber(str:sub(3, 4), 16) / 255, tonumber(str:sub(5, 6), 16) / 255
+			else
+				--parse seperate values
+				r,g,b = str:match("^([%d%.]+) ([%d%.]+) ([%d%.]+)$")
+				r,g,b = tonumber(r), tonumber(g), tonumber(b)
+			end
+			if not (r and g and b) then
+				usererr(info, inputpos, format(L["'%s' - expected 'RRGGBB' or 'r g b'."], str))
+				return
+			end
+			if r >= 0.0 and r <= 1.0 and g >= 0.0 and g <= 1.0 and b >= 0.0 and b <= 1.0 then
+				--values are valid
+			elseif r >= 0 and r <= 255 and g >= 0 and g <= 255 and b >= 0 and b <= 255 then
+				--values are valid 0..255, convert to 0..1
+				r = r / 255
+				g = g / 255
+				b = b / 255
+			else
+				--values are invalid
+				usererr(info, inputpos, format(L["'%s' - values must all be either in the range 0-1 or 0-255."], str))
+			end
+		end
+
+		do_final(info, inputpos, tab, "set", r,g,b,a)
+
+	elseif tab.type=="keybinding" then
+		------------ keybinding --------------------------------------------
+		local str = strtrim(strlower(str))
+		if str == "" then
+			--TODO: Show current value
+			return
+		end
+		local value = keybindingValidateFunc(str:upper())
+		if value == false then
+			usererr(info, inputpos, format(L["'%s' - Invalid Keybinding."], str))
+			return
+		end
+
+		do_final(info, inputpos, tab, "set", value)
+
+	elseif tab.type=="description" then
+		------------ description --------------------
+		-- ignore description, GUI config only
+	else
+		err(info, inputpos, "unknown options table item type '"..tostring(tab.type).."'")
+	end
+end
+
+--- Handle the chat command.
+-- This is usually called from a chat command handler to parse the command input as operations on an aceoptions table.\\
+-- AceConfigCmd uses this function internally when a slash command is registered with `:CreateChatCommand`
+-- @param slashcmd The slash command WITHOUT leading slash (only used for error output)
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param input The commandline input (as given by the WoW handler, i.e. without the command itself)
+-- @usage
+-- MyAddon = LibStub("AceAddon-3.0"):NewAddon("MyAddon", "AceConsole-3.0")
+-- -- Use AceConsole-3.0 to register a Chat Command
+-- MyAddon:RegisterChatCommand("mychat", "ChatCommand")
+--
+-- -- Show the GUI if no input is supplied, otherwise handle the chat input.
+-- function MyAddon:ChatCommand(input)
+--   -- Assuming "MyOptions" is the appName of a valid options table
+--   if not input or input:trim() == "" then
+--     LibStub("AceConfigDialog-3.0"):Open("MyOptions")
+--   else
+--     LibStub("AceConfigCmd-3.0").HandleCommand(MyAddon, "mychat", "MyOptions", input)
+--   end
+-- end
+function AceConfigCmd:HandleCommand(slashcmd, appName, input)
+
+	local optgetter = cfgreg:GetOptionsTable(appName)
+	if not optgetter then
+		error([[Usage: HandleCommand("slashcmd", "appName", "input"): 'appName' - no options table "]]..tostring(appName)..[[" has been registered]], 2)
+	end
+	local options = assert( optgetter("cmd", MAJOR) )
+
+	local info = {   -- Don't try to recycle this, it gets handed off to callbacks and whatnot
+		[0] = slashcmd,
+		appName = appName,
+		options = options,
+		input = input,
+		self = self,
+		handler = self,
+		uiType = "cmd",
+		uiName = MAJOR,
+	}
+
+	handle(info, 1, options, 0)  -- (info, inputpos, table, depth)
+end
+
+--- Utility function to create a slash command handler.
+-- Also registers tab completion with AceTab
+-- @param slashcmd The slash command WITHOUT leading slash (only used for error output)
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+function AceConfigCmd:CreateChatCommand(slashcmd, appName)
+	if not AceConsole then
+		AceConsole = LibStub(AceConsoleName)
+	end
+	if AceConsole.RegisterChatCommand(self, slashcmd, function(input)
+				AceConfigCmd.HandleCommand(self, slashcmd, appName, input)	-- upgradable
+		end,
+	true) then -- succesfully registered so lets get the command -> app table in
+		commands[slashcmd] = appName
+	end
+end
+
+--- Utility function that returns the options table that belongs to a slashcommand.
+-- Designed to be used for the AceTab interface.
+-- @param slashcmd The slash command WITHOUT leading slash (only used for error output)
+-- @return The options table associated with the slash command (or nil if the slash command was not registered)
+function AceConfigCmd:GetChatCommandOptions(slashcmd)
+	return commands[slashcmd]
+end

--- a/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.xml
+++ b/Libs/AceConfig-3.0/AceConfigCmd-3.0/AceConfigCmd-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceConfigCmd-3.0.lua"/>
+</Ui>

--- a/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -1,0 +1,2019 @@
+--- AceConfigDialog-3.0 generates AceGUI-3.0 based windows based on option tables.
+-- @class file
+-- @name AceConfigDialog-3.0
+-- @release $Id: AceConfigDialog-3.0.lua 1248 2021-02-05 14:27:49Z funkehdude $
+
+local LibStub = LibStub
+local gui = LibStub("AceGUI-3.0")
+local reg = LibStub("AceConfigRegistry-3.0")
+
+local MAJOR, MINOR = "AceConfigDialog-3.0", 81
+local AceConfigDialog, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceConfigDialog then return end
+
+AceConfigDialog.OpenFrames = AceConfigDialog.OpenFrames or {}
+AceConfigDialog.Status = AceConfigDialog.Status or {}
+AceConfigDialog.frame = AceConfigDialog.frame or CreateFrame("Frame")
+AceConfigDialog.tooltip = AceConfigDialog.tooltip or CreateFrame("GameTooltip", "AceConfigDialogTooltip", UIParent, "GameTooltipTemplate")
+
+AceConfigDialog.frame.apps = AceConfigDialog.frame.apps or {}
+AceConfigDialog.frame.closing = AceConfigDialog.frame.closing or {}
+AceConfigDialog.frame.closeAllOverride = AceConfigDialog.frame.closeAllOverride or {}
+
+-- Lua APIs
+local tinsert, tsort, tremove, wipe = table.insert, table.sort, table.remove, table.wipe
+local strmatch, format = string.match, string.format
+local error = error
+local pairs, next, select, type, unpack, ipairs = pairs, next, select, type, unpack, ipairs
+local tostring, tonumber = tostring, tonumber
+local math_min, math_max, math_floor = math.min, math.max, math.floor
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: NORMAL_FONT_COLOR, ACCEPT, CANCEL
+-- GLOBALS: PlaySound, GameFontHighlight, GameFontHighlightSmall, GameFontHighlightLarge
+-- GLOBALS: CloseSpecialWindows, InterfaceOptions_AddCategory, geterrorhandler
+
+local emptyTbl = {}
+
+--[[
+	 xpcall safecall implementation
+]]
+local xpcall = xpcall
+
+local function errorhandler(err)
+	return geterrorhandler()(err)
+end
+
+local function safecall(func, ...)
+	if func then
+		return xpcall(func, errorhandler, ...)
+	end
+end
+
+local width_multiplier = 170
+
+--[[
+Group Types
+  Tree 	- All Descendant Groups will all become nodes on the tree, direct child options will appear above the tree
+        - Descendant Groups with inline=true and thier children will not become nodes
+
+  Tab	- Direct Child Groups will become tabs, direct child options will appear above the tab control
+        - Grandchild groups will default to inline unless specified otherwise
+
+  Select- Same as Tab but with entries in a dropdown rather than tabs
+
+
+  Inline Groups
+    - Will not become nodes of a select group, they will be effectivly part of thier parent group seperated by a border
+    - If declared on a direct child of a root node of a select group, they will appear above the group container control
+    - When a group is displayed inline, all descendants will also be inline members of the group
+
+]]
+
+-- Recycling functions
+local new, del, copy
+--newcount, delcount,createdcount,cached = 0,0,0
+do
+	local pool = setmetatable({},{__mode="k"})
+	function new()
+		--newcount = newcount + 1
+		local t = next(pool)
+		if t then
+			pool[t] = nil
+			return t
+		else
+			--createdcount = createdcount + 1
+			return {}
+		end
+	end
+	function copy(t)
+		local c = new()
+		for k, v in pairs(t) do
+			c[k] = v
+		end
+		return c
+	end
+	function del(t)
+		--delcount = delcount + 1
+		wipe(t)
+		pool[t] = true
+	end
+--	function cached()
+--		local n = 0
+--		for k in pairs(pool) do
+--			n = n + 1
+--		end
+--		return n
+--	end
+end
+
+-- picks the first non-nil value and returns it
+local function pickfirstset(...)
+  for i=1,select("#",...) do
+    if select(i,...)~=nil then
+      return select(i,...)
+    end
+  end
+end
+
+--gets an option from a given group, checking plugins
+local function GetSubOption(group, key)
+	if group.plugins then
+		for plugin, t in pairs(group.plugins) do
+			if t[key] then
+				return t[key]
+			end
+		end
+	end
+
+	return group.args[key]
+end
+
+--Option member type definitions, used to decide how to access it
+
+--Is the member Inherited from parent options
+local isInherited = {
+	set = true,
+	get = true,
+	func = true,
+	confirm = true,
+	validate = true,
+	disabled = true,
+	hidden = true
+}
+
+--Does a string type mean a literal value, instead of the default of a method of the handler
+local stringIsLiteral = {
+	name = true,
+	desc = true,
+	icon = true,
+	usage = true,
+	width = true,
+	image = true,
+	fontSize = true,
+}
+
+--Is Never a function or method
+local allIsLiteral = {
+	type = true,
+	descStyle = true,
+	imageWidth = true,
+	imageHeight = true,
+}
+
+--gets the value for a member that could be a function
+--function refs are called with an info arg
+--every other type is returned
+local function GetOptionsMemberValue(membername, option, options, path, appName, ...)
+	--get definition for the member
+	local inherits = isInherited[membername]
+
+
+	--get the member of the option, traversing the tree if it can be inherited
+	local member
+
+	if inherits then
+		local group = options
+		if group[membername] ~= nil then
+			member = group[membername]
+		end
+		for i = 1, #path do
+			group = GetSubOption(group, path[i])
+			if group[membername] ~= nil then
+				member = group[membername]
+			end
+		end
+	else
+		member = option[membername]
+	end
+
+	--check if we need to call a functon, or if we have a literal value
+	if ( not allIsLiteral[membername] ) and ( type(member) == "function" or ((not stringIsLiteral[membername]) and type(member) == "string") ) then
+		--We have a function to call
+		local info = new()
+		--traverse the options table, picking up the handler and filling the info with the path
+		local handler
+		local group = options
+		handler = group.handler or handler
+
+		for i = 1, #path do
+			group = GetSubOption(group, path[i])
+			info[i] = path[i]
+			handler = group.handler or handler
+		end
+
+		info.options = options
+		info.appName = appName
+		info[0] = appName
+		info.arg = option.arg
+		info.handler = handler
+		info.option = option
+		info.type = option.type
+		info.uiType = "dialog"
+		info.uiName = MAJOR
+
+		local a, b, c ,d
+		--using 4 returns for the get of a color type, increase if a type needs more
+		if type(member) == "function" then
+			--Call the function
+			a,b,c,d = member(info, ...)
+		else
+			--Call the method
+			if handler and handler[member] then
+				a,b,c,d = handler[member](handler, info, ...)
+			else
+				error(format("Method %s doesn't exist in handler for type %s", member, membername))
+			end
+		end
+		del(info)
+		return a,b,c,d
+	else
+		--The value isnt a function to call, return it
+		return member
+	end
+end
+
+--[[calls an options function that could be inherited, method name or function ref
+local function CallOptionsFunction(funcname ,option, options, path, appName, ...)
+	local info = new()
+
+	local func
+	local group = options
+	local handler
+
+	--build the info table containing the path
+	-- pick up functions while traversing the tree
+	if group[funcname] ~= nil then
+		func = group[funcname]
+	end
+	handler = group.handler or handler
+
+	for i, v in ipairs(path) do
+		group = GetSubOption(group, v)
+		info[i] = v
+		if group[funcname] ~= nil then
+			func =  group[funcname]
+		end
+		handler = group.handler or handler
+	end
+
+	info.options = options
+	info[0] = appName
+	info.arg = option.arg
+
+	local a, b, c ,d
+	if type(func) == "string" then
+		if handler and handler[func] then
+			a,b,c,d = handler[func](handler, info, ...)
+		else
+			error(string.format("Method %s doesn't exist in handler for type func", func))
+		end
+	elseif type(func) == "function" then
+		a,b,c,d = func(info, ...)
+	end
+	del(info)
+	return a,b,c,d
+end
+--]]
+
+--tables to hold orders and names for options being sorted, will be created with new()
+--prevents needing to call functions repeatedly while sorting
+local tempOrders
+local tempNames
+
+local function compareOptions(a,b)
+	if not a then
+		return true
+	end
+	if not b then
+		return false
+	end
+	local OrderA, OrderB = tempOrders[a] or 100, tempOrders[b] or 100
+	if OrderA == OrderB then
+		local NameA = (type(tempNames[a]) == "string") and tempNames[a] or ""
+		local NameB = (type(tempNames[b]) == "string") and tempNames[b] or ""
+		return NameA:upper() < NameB:upper()
+	end
+	if OrderA < 0 then
+		if OrderB >= 0 then
+			return false
+		end
+	else
+		if OrderB < 0 then
+			return true
+		end
+	end
+	return OrderA < OrderB
+end
+
+
+
+--builds 2 tables out of an options group
+-- keySort, sorted keys
+-- opts, combined options from .plugins and args
+local function BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+	tempOrders = new()
+	tempNames = new()
+
+	if group.plugins then
+		for plugin, t in pairs(group.plugins) do
+			for k, v in pairs(t) do
+				if not opts[k] then
+					tinsert(keySort, k)
+					opts[k] = v
+
+					path[#path+1] = k
+					tempOrders[k] = GetOptionsMemberValue("order", v, options, path, appName)
+					tempNames[k] = GetOptionsMemberValue("name", v, options, path, appName)
+					path[#path] = nil
+				end
+			end
+		end
+	end
+
+	for k, v in pairs(group.args) do
+		if not opts[k] then
+			tinsert(keySort, k)
+			opts[k] = v
+
+			path[#path+1] = k
+			tempOrders[k] = GetOptionsMemberValue("order", v, options, path, appName)
+			tempNames[k] = GetOptionsMemberValue("name", v, options, path, appName)
+			path[#path] = nil
+		end
+	end
+
+	tsort(keySort, compareOptions)
+
+	del(tempOrders)
+	del(tempNames)
+end
+
+local function DelTree(tree)
+	if tree.children then
+		local childs = tree.children
+		for i = 1, #childs do
+			DelTree(childs[i])
+			del(childs[i])
+		end
+		del(childs)
+	end
+end
+
+local function CleanUserData(widget, event)
+
+	local user = widget:GetUserDataTable()
+
+	if user.path then
+		del(user.path)
+	end
+
+	if widget.type == "TreeGroup" then
+		local tree = user.tree
+		widget:SetTree(nil)
+		if tree then
+			for i = 1, #tree do
+				DelTree(tree[i])
+				del(tree[i])
+			end
+			del(tree)
+		end
+	end
+
+	if widget.type == "TabGroup" then
+		widget:SetTabs(nil)
+		if user.tablist then
+			del(user.tablist)
+		end
+	end
+
+	if widget.type == "DropdownGroup" then
+		widget:SetGroupList(nil)
+		if user.grouplist then
+			del(user.grouplist)
+		end
+		if user.orderlist then
+			del(user.orderlist)
+		end
+	end
+end
+
+-- - Gets a status table for the given appname and options path.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param path The path to the options (a table with all group keys)
+-- @return
+function AceConfigDialog:GetStatusTable(appName, path)
+	local status = self.Status
+
+	if not status[appName] then
+		status[appName] = {}
+		status[appName].status = {}
+		status[appName].children = {}
+	end
+
+	status = status[appName]
+
+	if path then
+		for i = 1, #path do
+			local v = path[i]
+			if not status.children[v] then
+				status.children[v] = {}
+				status.children[v].status = {}
+				status.children[v].children = {}
+			end
+			status = status.children[v]
+		end
+	end
+
+	return status.status
+end
+
+--- Selects the specified path in the options window.
+-- The path specified has to match the keys of the groups in the table.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param ... The path to the key that should be selected
+function AceConfigDialog:SelectGroup(appName, ...)
+	local path = new()
+
+
+	local app = reg:GetOptionsTable(appName)
+	if not app then
+		error(("%s isn't registed with AceConfigRegistry, unable to open config"):format(appName), 2)
+	end
+	local options = app("dialog", MAJOR)
+	local group = options
+	local status = self:GetStatusTable(appName, path)
+	if not status.groups then
+		status.groups = {}
+	end
+	status = status.groups
+	local treevalue
+	local treestatus
+
+	for n = 1, select("#",...) do
+		local key = select(n, ...)
+
+		if group.childGroups == "tab" or group.childGroups == "select" then
+			--if this is a tab or select group, select the group
+			status.selected = key
+			--children of this group are no longer extra levels of a tree
+			treevalue = nil
+		else
+			--tree group by default
+			if treevalue then
+				--this is an extra level of a tree group, build a uniquevalue for it
+				treevalue = treevalue.."\001"..key
+			else
+				--this is the top level of a tree group, the uniquevalue is the same as the key
+				treevalue = key
+				if not status.groups then
+					status.groups = {}
+				end
+				--save this trees status table for any extra levels or groups
+				treestatus = status
+			end
+			--make sure that the tree entry is open, and select it.
+			--the selected group will be overwritten if a child is the final target but still needs to be open
+			treestatus.selected = treevalue
+			treestatus.groups[treevalue] = true
+
+		end
+
+		--move to the next group in the path
+		group = GetSubOption(group, key)
+		if not group then
+			break
+		end
+		tinsert(path, key)
+		status = self:GetStatusTable(appName, path)
+		if not status.groups then
+			status.groups = {}
+		end
+		status = status.groups
+	end
+
+	del(path)
+	reg:NotifyChange(appName)
+end
+
+local function OptionOnMouseOver(widget, event)
+	--show a tooltip/set the status bar to the desc text
+	local user = widget:GetUserDataTable()
+	local opt = user.option
+	local options = user.options
+	local path = user.path
+	local appName = user.appName
+	local tooltip = AceConfigDialog.tooltip
+
+	tooltip:SetOwner(widget.frame, "ANCHOR_TOPRIGHT")
+	local name = GetOptionsMemberValue("name", opt, options, path, appName)
+	local desc = GetOptionsMemberValue("desc", opt, options, path, appName)
+	local usage = GetOptionsMemberValue("usage", opt, options, path, appName)
+	local descStyle = opt.descStyle
+
+	if descStyle and descStyle ~= "tooltip" then return end
+
+	tooltip:SetText(name, 1, .82, 0, true)
+
+	if opt.type == "multiselect" then
+		tooltip:AddLine(user.text, 0.5, 0.5, 0.8, true)
+	end
+	if type(desc) == "string" then
+		tooltip:AddLine(desc, 1, 1, 1, true)
+	end
+	if type(usage) == "string" then
+		tooltip:AddLine("Usage: "..usage, NORMAL_FONT_COLOR.r, NORMAL_FONT_COLOR.g, NORMAL_FONT_COLOR.b, true)
+	end
+
+	tooltip:Show()
+end
+
+local function OptionOnMouseLeave(widget, event)
+	AceConfigDialog.tooltip:Hide()
+end
+
+local function GetFuncName(option)
+	local type = option.type
+	if type == "execute" then
+		return "func"
+	else
+		return "set"
+	end
+end
+do
+	local frame = AceConfigDialog.popup
+	if not frame or oldminor < 81 then
+		frame = CreateFrame("Frame", nil, UIParent)
+		AceConfigDialog.popup = frame
+		frame:Hide()
+		frame:SetPoint("CENTER", UIParent, "CENTER")
+		frame:SetSize(320, 72)
+		frame:EnableMouse(true) -- Do not allow click-through on the frame
+		frame:SetFrameStrata("TOOLTIP")
+		frame:SetFrameLevel(100) -- Lots of room to draw under it
+		frame:SetScript("OnKeyDown", function(self, key)
+			if key == "ESCAPE" then
+				self:SetPropagateKeyboardInput(false)
+				if self.cancel:IsShown() then
+					self.cancel:Click()
+				else -- Showing a validation error
+					self:Hide()
+				end
+			else
+				self:SetPropagateKeyboardInput(true)
+			end
+		end)
+
+		if not frame.SetFixedFrameStrata then -- API capability check (classic check)
+			frame:SetBackdrop({
+				bgFile = [[Interface\DialogFrame\UI-DialogBox-Background-Dark]],
+				edgeFile = [[Interface\DialogFrame\UI-DialogBox-Border]],
+				tile = true,
+				tileSize = 32,
+				edgeSize = 32,
+				insets = { left = 11, right = 11, top = 11, bottom = 11 },
+			})
+		else
+			local border = CreateFrame("Frame", nil, frame, "DialogBorderOpaqueTemplate")
+			border:SetAllPoints(frame)
+			frame:SetFixedFrameStrata(true)
+			frame:SetFixedFrameLevel(true)
+		end
+
+		local text = frame:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+		text:SetSize(290, 0)
+		text:SetPoint("TOP", 0, -16)
+		frame.text = text
+
+		local function newButton(text)
+			local button = CreateFrame("Button", nil, frame)
+			button:SetSize(128, 21)
+			button:SetNormalFontObject(GameFontNormal)
+			button:SetHighlightFontObject(GameFontHighlight)
+			button:SetNormalTexture(130763) -- "Interface\\Buttons\\UI-DialogBox-Button-Up"
+			button:GetNormalTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetPushedTexture(130761) -- "Interface\\Buttons\\UI-DialogBox-Button-Down"
+			button:GetPushedTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetHighlightTexture(130762) -- "Interface\\Buttons\\UI-DialogBox-Button-Highlight"
+			button:GetHighlightTexture():SetTexCoord(0.0, 1.0, 0.0, 0.71875)
+			button:SetText(text)
+			return button
+		end
+
+		local accept = newButton(ACCEPT)
+		accept:SetPoint("BOTTOMRIGHT", frame, "BOTTOM", -6, 16)
+		frame.accept = accept
+
+		local cancel = newButton(CANCEL)
+		cancel:SetPoint("LEFT", accept, "RIGHT", 13, 0)
+		frame.cancel = cancel
+	end
+end
+local function confirmPopup(appName, rootframe, basepath, info, message, func, ...)
+	local frame = AceConfigDialog.popup
+	frame:Show()
+	frame.text:SetText(message)
+	-- From StaticPopup.lua
+	-- local height = 32 + text:GetHeight() + 2;
+	-- height = height + 6 + accept:GetHeight()
+	-- We add 32 + 2 + 6 + 21 (button height) == 61
+	local height = 61 + frame.text:GetHeight()
+	frame:SetHeight(height)
+
+	frame.accept:ClearAllPoints()
+	frame.accept:SetPoint("BOTTOMRIGHT", frame, "BOTTOM", -6, 16)
+	frame.cancel:Show()
+
+	local t = {...}
+	local tCount = select("#", ...)
+	frame.accept:SetScript("OnClick", function(self)
+		safecall(func, unpack(t, 1, tCount)) -- Manually set count as unpack() stops on nil (bug with #table)
+		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
+		frame:Hide()
+		self:SetScript("OnClick", nil)
+		frame.cancel:SetScript("OnClick", nil)
+		del(info)
+	end)
+	frame.cancel:SetScript("OnClick", function(self)
+		AceConfigDialog:Open(appName, rootframe, unpack(basepath or emptyTbl))
+		frame:Hide()
+		self:SetScript("OnClick", nil)
+		frame.accept:SetScript("OnClick", nil)
+		del(info)
+	end)
+end
+
+local function validationErrorPopup(message)
+	local frame = AceConfigDialog.popup
+	frame:Show()
+	frame.text:SetText(message)
+	-- From StaticPopup.lua
+	-- local height = 32 + text:GetHeight() + 2;
+	-- height = height + 6 + accept:GetHeight()
+	-- We add 32 + 2 + 6 + 21 (button height) == 61
+	local height = 61 + frame.text:GetHeight()
+	frame:SetHeight(height)
+
+	frame.accept:ClearAllPoints()
+	frame.accept:SetPoint("BOTTOM", frame, "BOTTOM", 0, 16)
+	frame.cancel:Hide()
+
+	frame.accept:SetScript("OnClick", function()
+		frame:Hide()
+	end)
+end
+
+local function ActivateControl(widget, event, ...)
+	--This function will call the set / execute handler for the widget
+	--widget:GetUserDataTable() contains the needed info
+	local user = widget:GetUserDataTable()
+	local option = user.option
+	local options = user.options
+	local path = user.path
+	local info = new()
+
+	local func
+	local group = options
+	local funcname = GetFuncName(option)
+	local handler
+	local confirm
+	local validate
+	--build the info table containing the path
+	-- pick up functions while traversing the tree
+	if group[funcname] ~= nil then
+		func =  group[funcname]
+	end
+	handler = group.handler or handler
+	confirm = group.confirm
+	validate = group.validate
+	for i = 1, #path do
+		local v = path[i]
+		group = GetSubOption(group, v)
+		info[i] = v
+		if group[funcname] ~= nil then
+			func =  group[funcname]
+		end
+		handler = group.handler or handler
+		if group.confirm ~= nil then
+			confirm = group.confirm
+		end
+		if group.validate ~= nil then
+			validate = group.validate
+		end
+	end
+
+	info.options = options
+	info.appName = user.appName
+	info.arg = option.arg
+	info.handler = handler
+	info.option = option
+	info.type = option.type
+	info.uiType = "dialog"
+	info.uiName = MAJOR
+
+	local name
+	if type(option.name) == "function" then
+		name = option.name(info)
+	elseif type(option.name) == "string" then
+		name = option.name
+	else
+		name = ""
+	end
+	local usage = option.usage
+	local pattern = option.pattern
+
+	local validated = true
+
+	if option.type == "input" then
+		if type(pattern)=="string" then
+			if not strmatch(..., pattern) then
+				validated = false
+			end
+		end
+	end
+
+	local success
+	if validated and option.type ~= "execute" then
+		if type(validate) == "string" then
+			if handler and handler[validate] then
+				success, validated = safecall(handler[validate], handler, info, ...)
+				if not success then validated = false end
+			else
+				error(format("Method %s doesn't exist in handler for type execute", validate))
+			end
+		elseif type(validate) == "function" then
+			success, validated = safecall(validate, info, ...)
+			if not success then validated = false end
+		end
+	end
+
+	local rootframe = user.rootframe
+	if not validated or type(validated) == "string" then
+		if not validated then
+			if usage then
+				validated = name..": "..usage
+			else
+				if pattern then
+					validated = name..": Expected "..pattern
+				else
+					validated = name..": Invalid Value"
+				end
+			end
+		end
+
+		-- show validate message
+		if rootframe.SetStatusText then
+			rootframe:SetStatusText(validated)
+		else
+			validationErrorPopup(validated)
+		end
+		PlaySound(882) -- SOUNDKIT.IG_PLAYER_INVITE_DECLINE || _DECLINE is actually missing from the table
+		del(info)
+		return true
+	else
+
+		local confirmText = option.confirmText
+		--call confirm func/method
+		if type(confirm) == "string" then
+			if handler and handler[confirm] then
+				success, confirm = safecall(handler[confirm], handler, info, ...)
+				if success and type(confirm) == "string" then
+					confirmText = confirm
+					confirm = true
+				elseif not success then
+					confirm = false
+				end
+			else
+				error(format("Method %s doesn't exist in handler for type confirm", confirm))
+			end
+		elseif type(confirm) == "function" then
+			success, confirm = safecall(confirm, info, ...)
+			if success and type(confirm) == "string" then
+				confirmText = confirm
+				confirm = true
+			elseif not success then
+				confirm = false
+			end
+		end
+
+		--confirm if needed
+		if type(confirm) == "boolean" then
+			if confirm then
+				if not confirmText then
+					local name, desc = option.name, option.desc
+					if type(name) == "function" then
+						name = name(info)
+					end
+					if type(desc) == "function" then
+						desc = desc(info)
+					end
+					confirmText = name
+					if desc then
+						confirmText = confirmText.." - "..desc
+					end
+				end
+
+				local iscustom = user.rootframe:GetUserData("iscustom")
+				local rootframe
+
+				if iscustom then
+					rootframe = user.rootframe
+				end
+				local basepath = user.rootframe:GetUserData("basepath")
+				if type(func) == "string" then
+					if handler and handler[func] then
+						confirmPopup(user.appName, rootframe, basepath, info, confirmText, handler[func], handler, info, ...)
+					else
+						error(format("Method %s doesn't exist in handler for type func", func))
+					end
+				elseif type(func) == "function" then
+					confirmPopup(user.appName, rootframe, basepath, info, confirmText, func, info, ...)
+				end
+				--func will be called and info deleted when the confirm dialog is responded to
+				return
+			end
+		end
+
+		--call the function
+		if type(func) == "string" then
+			if handler and handler[func] then
+				safecall(handler[func],handler, info, ...)
+			else
+				error(format("Method %s doesn't exist in handler for type func", func))
+			end
+		elseif type(func) == "function" then
+			safecall(func,info, ...)
+		end
+
+
+
+		local iscustom = user.rootframe:GetUserData("iscustom")
+		local basepath = user.rootframe:GetUserData("basepath") or emptyTbl
+		--full refresh of the frame, some controls dont cause this on all events
+		if option.type == "color" then
+			if event == "OnValueConfirmed" then
+
+				if iscustom then
+					AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
+				else
+					AceConfigDialog:Open(user.appName, unpack(basepath))
+				end
+			end
+		elseif option.type == "range" then
+			if event == "OnMouseUp" then
+				if iscustom then
+					AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
+				else
+					AceConfigDialog:Open(user.appName, unpack(basepath))
+				end
+			end
+		--multiselects don't cause a refresh on 'OnValueChanged' only 'OnClosed'
+		elseif option.type == "multiselect" then
+			user.valuechanged = true
+		else
+			if iscustom then
+				AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
+			else
+				AceConfigDialog:Open(user.appName, unpack(basepath))
+			end
+		end
+
+	end
+	del(info)
+end
+
+local function ActivateSlider(widget, event, value)
+	local option = widget:GetUserData("option")
+	local min, max, step = option.min or (not option.softMin and 0 or nil), option.max or (not option.softMax and 100 or nil), option.step
+	if min then
+		if step then
+			value = math_floor((value - min) / step + 0.5) * step + min
+		end
+		value = math_max(value, min)
+	end
+	if max then
+		value = math_min(value, max)
+	end
+	ActivateControl(widget,event,value)
+end
+
+--called from a checkbox that is part of an internally created multiselect group
+--this type is safe to refresh on activation of one control
+local function ActivateMultiControl(widget, event, ...)
+	ActivateControl(widget, event, widget:GetUserData("value"), ...)
+	local user = widget:GetUserDataTable()
+	local iscustom = user.rootframe:GetUserData("iscustom")
+	local basepath = user.rootframe:GetUserData("basepath") or emptyTbl
+	if iscustom then
+		AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
+	else
+		AceConfigDialog:Open(user.appName, unpack(basepath))
+	end
+end
+
+local function MultiControlOnClosed(widget, event, ...)
+	local user = widget:GetUserDataTable()
+	if user.valuechanged and not widget:IsReleasing() then
+		local iscustom = user.rootframe:GetUserData("iscustom")
+		local basepath = user.rootframe:GetUserData("basepath") or emptyTbl
+		if iscustom then
+			AceConfigDialog:Open(user.appName, user.rootframe, unpack(basepath))
+		else
+			AceConfigDialog:Open(user.appName, unpack(basepath))
+		end
+	end
+end
+
+local function FrameOnClose(widget, event)
+	local appName = widget:GetUserData("appName")
+	AceConfigDialog.OpenFrames[appName] = nil
+	gui:Release(widget)
+end
+
+local function CheckOptionHidden(option, options, path, appName)
+	--check for a specific boolean option
+	local hidden = pickfirstset(option.dialogHidden,option.guiHidden)
+	if hidden ~= nil then
+		return hidden
+	end
+
+	return GetOptionsMemberValue("hidden", option, options, path, appName)
+end
+
+local function CheckOptionDisabled(option, options, path, appName)
+	--check for a specific boolean option
+	local disabled = pickfirstset(option.dialogDisabled,option.guiDisabled)
+	if disabled ~= nil then
+		return disabled
+	end
+
+	return GetOptionsMemberValue("disabled", option, options, path, appName)
+end
+--[[
+local function BuildTabs(group, options, path, appName)
+	local tabs = new()
+	local text = new()
+	local keySort = new()
+	local opts = new()
+
+	BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+
+	for i = 1, #keySort do
+		local k = keySort[i]
+		local v = opts[k]
+		if v.type == "group" then
+			path[#path+1] = k
+			local inline = pickfirstset(v.dialogInline,v.guiInline,v.inline, false)
+			local hidden = CheckOptionHidden(v, options, path, appName)
+			if not inline and not hidden then
+				tinsert(tabs, k)
+				text[k] = GetOptionsMemberValue("name", v, options, path, appName)
+			end
+			path[#path] = nil
+		end
+	end
+
+	del(keySort)
+	del(opts)
+
+	return tabs, text
+end
+]]
+local function BuildSelect(group, options, path, appName)
+	local groups = new()
+	local order = new()
+	local keySort = new()
+	local opts = new()
+
+	BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+
+	for i = 1, #keySort do
+		local k = keySort[i]
+		local v = opts[k]
+		if v.type == "group" then
+			path[#path+1] = k
+			local inline = pickfirstset(v.dialogInline,v.guiInline,v.inline, false)
+			local hidden = CheckOptionHidden(v, options, path, appName)
+			if not inline and not hidden then
+				groups[k] = GetOptionsMemberValue("name", v, options, path, appName)
+				tinsert(order, k)
+			end
+			path[#path] = nil
+		end
+	end
+
+	del(opts)
+	del(keySort)
+
+	return groups, order
+end
+
+local function BuildSubGroups(group, tree, options, path, appName)
+	local keySort = new()
+	local opts = new()
+
+	BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+
+	for i = 1, #keySort do
+		local k = keySort[i]
+		local v = opts[k]
+		if v.type == "group" then
+			path[#path+1] = k
+			local inline = pickfirstset(v.dialogInline,v.guiInline,v.inline, false)
+			local hidden = CheckOptionHidden(v, options, path, appName)
+			if not inline and not hidden then
+				local entry = new()
+				entry.value = k
+				entry.text = GetOptionsMemberValue("name", v, options, path, appName)
+				entry.icon = GetOptionsMemberValue("icon", v, options, path, appName)
+				entry.iconCoords = GetOptionsMemberValue("iconCoords", v, options, path, appName)
+				entry.disabled = CheckOptionDisabled(v, options, path, appName)
+				if not tree.children then tree.children = new() end
+				tinsert(tree.children,entry)
+				if (v.childGroups or "tree") == "tree" then
+					BuildSubGroups(v,entry, options, path, appName)
+				end
+			end
+			path[#path] = nil
+		end
+	end
+
+	del(keySort)
+	del(opts)
+end
+
+local function BuildGroups(group, options, path, appName, recurse)
+	local tree = new()
+	local keySort = new()
+	local opts = new()
+
+	BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+
+	for i = 1, #keySort do
+		local k = keySort[i]
+		local v = opts[k]
+		if v.type == "group" then
+			path[#path+1] = k
+			local inline = pickfirstset(v.dialogInline,v.guiInline,v.inline, false)
+			local hidden = CheckOptionHidden(v, options, path, appName)
+			if not inline and not hidden then
+				local entry = new()
+				entry.value = k
+				entry.text = GetOptionsMemberValue("name", v, options, path, appName)
+				entry.icon = GetOptionsMemberValue("icon", v, options, path, appName)
+				entry.iconCoords = GetOptionsMemberValue("iconCoords", v, options, path, appName)
+				entry.disabled = CheckOptionDisabled(v, options, path, appName)
+				tinsert(tree,entry)
+				if recurse and (v.childGroups or "tree") == "tree" then
+					BuildSubGroups(v,entry, options, path, appName)
+				end
+			end
+			path[#path] = nil
+		end
+	end
+	del(keySort)
+	del(opts)
+	return tree
+end
+
+local function InjectInfo(control, options, option, path, rootframe, appName)
+	local user = control:GetUserDataTable()
+	for i = 1, #path do
+		user[i] = path[i]
+	end
+	user.rootframe = rootframe
+	user.option = option
+	user.options = options
+	user.path = copy(path)
+	user.appName = appName
+	control:SetCallback("OnRelease", CleanUserData)
+	control:SetCallback("OnLeave", OptionOnMouseLeave)
+	control:SetCallback("OnEnter", OptionOnMouseOver)
+end
+
+local function CreateControl(userControlType, fallbackControlType)
+	local control
+	if userControlType then
+		control = gui:Create(userControlType)
+		if not control then
+			geterrorhandler()(("Invalid Custom Control Type - %s"):format(tostring(userControlType)))
+		end
+	end
+	if not control then
+		control = gui:Create(fallbackControlType)
+	end
+	return control
+end
+
+local function sortTblAsStrings(x,y)
+	return tostring(x) < tostring(y) -- Support numbers as keys
+end
+
+--[[
+	options - root of the options table being fed
+	container - widget that controls will be placed in
+	rootframe - Frame object the options are in
+	path - table with the keys to get to the group being fed
+--]]
+
+local function FeedOptions(appName, options,container,rootframe,path,group,inline)
+	local keySort = new()
+	local opts = new()
+
+	BuildSortedOptionsTable(group, keySort, opts, options, path, appName)
+
+	for i = 1, #keySort do
+		local k = keySort[i]
+		local v = opts[k]
+		tinsert(path, k)
+		local hidden = CheckOptionHidden(v, options, path, appName)
+		local name = GetOptionsMemberValue("name", v, options, path, appName)
+		if not hidden then
+			if v.type == "group" then
+				if inline or pickfirstset(v.dialogInline,v.guiInline,v.inline, false) then
+					--Inline group
+					local GroupContainer
+					if name and name ~= "" then
+						GroupContainer = gui:Create("InlineGroup")
+						GroupContainer:SetTitle(name or "")
+					else
+						GroupContainer = gui:Create("SimpleGroup")
+					end
+
+					GroupContainer.width = "fill"
+					GroupContainer:SetLayout("flow")
+					container:AddChild(GroupContainer)
+					FeedOptions(appName,options,GroupContainer,rootframe,path,v,true)
+				end
+			else
+				--Control to feed
+				local control
+
+				local name = GetOptionsMemberValue("name", v, options, path, appName)
+
+				if v.type == "execute" then
+
+					local imageCoords = GetOptionsMemberValue("imageCoords",v, options, path, appName)
+					local image, width, height = GetOptionsMemberValue("image",v, options, path, appName)
+
+					local iconControl = type(image) == "string" or type(image) == "number"
+					control = CreateControl(v.dialogControl or v.control, iconControl and "Icon" or "Button")
+					if iconControl then
+						if not width then
+							width = GetOptionsMemberValue("imageWidth",v, options, path, appName)
+						end
+						if not height then
+							height = GetOptionsMemberValue("imageHeight",v, options, path, appName)
+						end
+						if type(imageCoords) == "table" then
+							control:SetImage(image, unpack(imageCoords))
+						else
+							control:SetImage(image)
+						end
+						if type(width) ~= "number" then
+							width = 32
+						end
+						if type(height) ~= "number" then
+							height = 32
+						end
+						control:SetImageSize(width, height)
+						control:SetLabel(name)
+					else
+						control:SetText(name)
+					end
+					control:SetCallback("OnClick",ActivateControl)
+
+				elseif v.type == "input" then
+					control = CreateControl(v.dialogControl or v.control, v.multiline and "MultiLineEditBox" or "EditBox")
+
+					if v.multiline and control.SetNumLines then
+						control:SetNumLines(tonumber(v.multiline) or 4)
+					end
+					control:SetLabel(name)
+					control:SetCallback("OnEnterPressed",ActivateControl)
+					local text = GetOptionsMemberValue("get",v, options, path, appName)
+					if type(text) ~= "string" then
+						text = ""
+					end
+					control:SetText(text)
+
+				elseif v.type == "toggle" then
+					control = CreateControl(v.dialogControl or v.control, "CheckBox")
+					control:SetLabel(name)
+					control:SetTriState(v.tristate)
+					local value = GetOptionsMemberValue("get",v, options, path, appName)
+					control:SetValue(value)
+					control:SetCallback("OnValueChanged",ActivateControl)
+
+					if v.descStyle == "inline" then
+						local desc = GetOptionsMemberValue("desc", v, options, path, appName)
+						control:SetDescription(desc)
+					end
+
+					local image = GetOptionsMemberValue("image", v, options, path, appName)
+					local imageCoords = GetOptionsMemberValue("imageCoords", v, options, path, appName)
+
+					if type(image) == "string" or type(image) == "number" then
+						if type(imageCoords) == "table" then
+							control:SetImage(image, unpack(imageCoords))
+						else
+							control:SetImage(image)
+						end
+					end
+				elseif v.type == "range" then
+					control = CreateControl(v.dialogControl or v.control, "Slider")
+					control:SetLabel(name)
+					control:SetSliderValues(v.softMin or v.min or 0, v.softMax or v.max or 100, v.bigStep or v.step or 0)
+					control:SetIsPercent(v.isPercent)
+					local value = GetOptionsMemberValue("get",v, options, path, appName)
+					if type(value) ~= "number" then
+						value = 0
+					end
+					control:SetValue(value)
+					control:SetCallback("OnValueChanged",ActivateSlider)
+					control:SetCallback("OnMouseUp",ActivateSlider)
+
+				elseif v.type == "select" then
+					local values = GetOptionsMemberValue("values", v, options, path, appName)
+					local sorting = GetOptionsMemberValue("sorting", v, options, path, appName)
+					if v.style == "radio" then
+						local disabled = CheckOptionDisabled(v, options, path, appName)
+						local width = GetOptionsMemberValue("width",v,options,path,appName)
+						control = gui:Create("InlineGroup")
+						control:SetLayout("Flow")
+						control:SetTitle(name)
+						control.width = "fill"
+
+						control:PauseLayout()
+						local optionValue = GetOptionsMemberValue("get",v, options, path, appName)
+						if not sorting then
+							sorting = {}
+							for value, text in pairs(values) do
+								sorting[#sorting+1]=value
+							end
+							tsort(sorting, sortTblAsStrings)
+						end
+						for k, value in ipairs(sorting) do
+							local text = values[value]
+							local radio = gui:Create("CheckBox")
+							radio:SetLabel(text)
+							radio:SetUserData("value", value)
+							radio:SetUserData("text", text)
+							radio:SetDisabled(disabled)
+							radio:SetType("radio")
+							radio:SetValue(optionValue == value)
+							radio:SetCallback("OnValueChanged", ActivateMultiControl)
+							InjectInfo(radio, options, v, path, rootframe, appName)
+							control:AddChild(radio)
+							if width == "double" then
+								radio:SetWidth(width_multiplier * 2)
+							elseif width == "half" then
+								radio:SetWidth(width_multiplier / 2)
+							elseif (type(width) == "number") then
+								radio:SetWidth(width_multiplier * width)
+							elseif width == "full" then
+								radio.width = "fill"
+							else
+								radio:SetWidth(width_multiplier)
+							end
+						end
+						control:ResumeLayout()
+						control:DoLayout()
+					else
+						control = CreateControl(v.dialogControl or v.control, "Dropdown")
+						local itemType = v.itemControl
+						if itemType and not gui:GetWidgetVersion(itemType) then
+							geterrorhandler()(("Invalid Custom Item Type - %s"):format(tostring(itemType)))
+							itemType = nil
+						end
+						control:SetLabel(name)
+						control:SetList(values, sorting, itemType)
+						local value = GetOptionsMemberValue("get",v, options, path, appName)
+						if not values[value] then
+							value = nil
+						end
+						control:SetValue(value)
+						control:SetCallback("OnValueChanged", ActivateControl)
+					end
+
+				elseif v.type == "multiselect" then
+					local values = GetOptionsMemberValue("values", v, options, path, appName)
+					local disabled = CheckOptionDisabled(v, options, path, appName)
+
+					local valuesort = new()
+					if values then
+						for value, text in pairs(values) do
+							tinsert(valuesort, value)
+						end
+					end
+					tsort(valuesort)
+
+					local controlType = v.dialogControl or v.control
+					if controlType then
+						control = gui:Create(controlType)
+						if not control then
+							geterrorhandler()(("Invalid Custom Control Type - %s"):format(tostring(controlType)))
+						end
+					end
+					if control then
+						control:SetMultiselect(true)
+						control:SetLabel(name)
+						control:SetList(values)
+						control:SetDisabled(disabled)
+						control:SetCallback("OnValueChanged",ActivateControl)
+						control:SetCallback("OnClosed", MultiControlOnClosed)
+						local width = GetOptionsMemberValue("width",v,options,path,appName)
+						if width == "double" then
+							control:SetWidth(width_multiplier * 2)
+						elseif width == "half" then
+							control:SetWidth(width_multiplier / 2)
+						elseif (type(width) == "number") then
+							control:SetWidth(width_multiplier * width)
+						elseif width == "full" then
+							control.width = "fill"
+						else
+							control:SetWidth(width_multiplier)
+						end
+						--check:SetTriState(v.tristate)
+						for i = 1, #valuesort do
+							local key = valuesort[i]
+							local value = GetOptionsMemberValue("get",v, options, path, appName, key)
+							control:SetItemValue(key,value)
+						end
+					else
+						control = gui:Create("InlineGroup")
+						control:SetLayout("Flow")
+						control:SetTitle(name)
+						control.width = "fill"
+
+						control:PauseLayout()
+						local width = GetOptionsMemberValue("width",v,options,path,appName)
+						for i = 1, #valuesort do
+							local value = valuesort[i]
+							local text = values[value]
+							local check = gui:Create("CheckBox")
+							check:SetLabel(text)
+							check:SetUserData("value", value)
+							check:SetUserData("text", text)
+							check:SetDisabled(disabled)
+							check:SetTriState(v.tristate)
+							check:SetValue(GetOptionsMemberValue("get",v, options, path, appName, value))
+							check:SetCallback("OnValueChanged",ActivateMultiControl)
+							InjectInfo(check, options, v, path, rootframe, appName)
+							control:AddChild(check)
+							if width == "double" then
+								check:SetWidth(width_multiplier * 2)
+							elseif width == "half" then
+								check:SetWidth(width_multiplier / 2)
+							elseif (type(width) == "number") then
+								control:SetWidth(width_multiplier * width)
+							elseif width == "full" then
+								check.width = "fill"
+							else
+								check:SetWidth(width_multiplier)
+							end
+						end
+						control:ResumeLayout()
+						control:DoLayout()
+
+
+					end
+
+					del(valuesort)
+
+				elseif v.type == "color" then
+					control = CreateControl(v.dialogControl or v.control, "ColorPicker")
+					control:SetLabel(name)
+					control:SetHasAlpha(GetOptionsMemberValue("hasAlpha",v, options, path, appName))
+					control:SetColor(GetOptionsMemberValue("get",v, options, path, appName))
+					control:SetCallback("OnValueChanged",ActivateControl)
+					control:SetCallback("OnValueConfirmed",ActivateControl)
+
+				elseif v.type == "keybinding" then
+					control = CreateControl(v.dialogControl or v.control, "Keybinding")
+					control:SetLabel(name)
+					control:SetKey(GetOptionsMemberValue("get",v, options, path, appName))
+					control:SetCallback("OnKeyChanged",ActivateControl)
+
+				elseif v.type == "header" then
+					control = CreateControl(v.dialogControl or v.control, "Heading")
+					control:SetText(name)
+					control.width = "fill"
+
+				elseif v.type == "description" then
+					control = CreateControl(v.dialogControl or v.control, "Label")
+					control:SetText(name)
+
+					local fontSize = GetOptionsMemberValue("fontSize",v, options, path, appName)
+					if fontSize == "medium" then
+						control:SetFontObject(GameFontHighlight)
+					elseif fontSize == "large" then
+						control:SetFontObject(GameFontHighlightLarge)
+					else -- small or invalid
+						control:SetFontObject(GameFontHighlightSmall)
+					end
+
+					local imageCoords = GetOptionsMemberValue("imageCoords",v, options, path, appName)
+					local image, width, height = GetOptionsMemberValue("image",v, options, path, appName)
+
+					if type(image) == "string" or type(image) == "number" then
+						if not width then
+							width = GetOptionsMemberValue("imageWidth",v, options, path, appName)
+						end
+						if not height then
+							height = GetOptionsMemberValue("imageHeight",v, options, path, appName)
+						end
+						if type(imageCoords) == "table" then
+							control:SetImage(image, unpack(imageCoords))
+						else
+							control:SetImage(image)
+						end
+						if type(width) ~= "number" then
+							width = 32
+						end
+						if type(height) ~= "number" then
+							height = 32
+						end
+						control:SetImageSize(width, height)
+					end
+					local width = GetOptionsMemberValue("width",v,options,path,appName)
+					control.width = not width and "fill"
+				end
+
+				--Common Init
+				if control then
+					if control.width ~= "fill" then
+						local width = GetOptionsMemberValue("width",v,options,path,appName)
+						if width == "double" then
+							control:SetWidth(width_multiplier * 2)
+						elseif width == "half" then
+							control:SetWidth(width_multiplier / 2)
+						elseif (type(width) == "number") then
+							control:SetWidth(width_multiplier * width)
+						elseif width == "full" then
+							control.width = "fill"
+						else
+							control:SetWidth(width_multiplier)
+						end
+					end
+					if control.SetDisabled then
+						local disabled = CheckOptionDisabled(v, options, path, appName)
+						control:SetDisabled(disabled)
+					end
+
+					InjectInfo(control, options, v, path, rootframe, appName)
+					container:AddChild(control)
+				end
+
+			end
+		end
+		tremove(path)
+	end
+	container:ResumeLayout()
+	container:DoLayout()
+	del(keySort)
+	del(opts)
+end
+
+local function BuildPath(path, ...)
+	for i = 1, select("#",...)  do
+		tinsert(path, (select(i,...)))
+	end
+end
+
+
+local function TreeOnButtonEnter(widget, event, uniquevalue, button)
+	local user = widget:GetUserDataTable()
+	if not user then return end
+	local options = user.options
+	local option = user.option
+	local path = user.path
+	local appName = user.appName
+	local tooltip = AceConfigDialog.tooltip
+
+	local feedpath = new()
+	for i = 1, #path do
+		feedpath[i] = path[i]
+	end
+
+	BuildPath(feedpath, ("\001"):split(uniquevalue))
+	local group = options
+	for i = 1, #feedpath do
+		if not group then return end
+		group = GetSubOption(group, feedpath[i])
+	end
+
+	local name = GetOptionsMemberValue("name", group, options, feedpath, appName)
+	local desc = GetOptionsMemberValue("desc", group, options, feedpath, appName)
+
+	tooltip:SetOwner(button, "ANCHOR_NONE")
+	tooltip:ClearAllPoints()
+	if widget.type == "TabGroup" then
+		tooltip:SetPoint("BOTTOM",button,"TOP")
+	else
+		tooltip:SetPoint("LEFT",button,"RIGHT")
+	end
+
+	tooltip:SetText(name, 1, .82, 0, true)
+
+	if type(desc) == "string" then
+		tooltip:AddLine(desc, 1, 1, 1, true)
+	end
+
+	tooltip:Show()
+end
+
+local function TreeOnButtonLeave(widget, event, value, button)
+	AceConfigDialog.tooltip:Hide()
+end
+
+
+local function GroupExists(appName, options, path, uniquevalue)
+	if not uniquevalue then return false end
+
+	local feedpath = new()
+	local temppath = new()
+	for i = 1, #path do
+		feedpath[i] = path[i]
+	end
+
+	BuildPath(feedpath, ("\001"):split(uniquevalue))
+
+	local group = options
+	for i = 1, #feedpath do
+		local v = feedpath[i]
+		temppath[i] = v
+		group = GetSubOption(group, v)
+
+		if not group or group.type ~= "group" or CheckOptionHidden(group, options, temppath, appName) then
+			del(feedpath)
+			del(temppath)
+			return false
+		end
+	end
+	del(feedpath)
+	del(temppath)
+	return true
+end
+
+local function GroupSelected(widget, event, uniquevalue)
+
+	local user = widget:GetUserDataTable()
+
+	local options = user.options
+	local option = user.option
+	local path = user.path
+	local rootframe = user.rootframe
+
+	local feedpath = new()
+	for i = 1, #path do
+		feedpath[i] = path[i]
+	end
+
+	BuildPath(feedpath, ("\001"):split(uniquevalue))
+	widget:ReleaseChildren()
+	AceConfigDialog:FeedGroup(user.appName,options,widget,rootframe,feedpath)
+
+	del(feedpath)
+end
+
+
+
+--[[
+-- INTERNAL --
+This function will feed one group, and any inline child groups into the given container
+Select Groups will only have the selection control (tree, tabs, dropdown) fed in
+and have a group selected, this event will trigger the feeding of child groups
+
+Rules:
+	If the group is Inline, FeedOptions
+	If the group has no child groups, FeedOptions
+
+	If the group is a tab or select group, FeedOptions then add the Group Control
+	If the group is a tree group FeedOptions then
+		its parent isnt a tree group:  then add the tree control containing this and all child tree groups
+		if its parent is a tree group, its already a node on a tree
+--]]
+
+function AceConfigDialog:FeedGroup(appName,options,container,rootframe,path, isRoot)
+	local group = options
+	--follow the path to get to the curent group
+	local inline
+	local grouptype, parenttype = options.childGroups, "none"
+
+
+	for i = 1, #path do
+		local v = path[i]
+		group = GetSubOption(group, v)
+		inline = inline or pickfirstset(v.dialogInline,v.guiInline,v.inline, false)
+		parenttype = grouptype
+		grouptype = group.childGroups
+	end
+
+	if not parenttype then
+		parenttype = "tree"
+	end
+
+	--check if the group has child groups
+	local hasChildGroups
+	for k, v in pairs(group.args) do
+		if v.type == "group" and not pickfirstset(v.dialogInline,v.guiInline,v.inline, false) and not CheckOptionHidden(v, options, path, appName) then
+			hasChildGroups = true
+		end
+	end
+	if group.plugins then
+		for plugin, t in pairs(group.plugins) do
+			for k, v in pairs(t) do
+				if v.type == "group" and not pickfirstset(v.dialogInline,v.guiInline,v.inline, false) and not CheckOptionHidden(v, options, path, appName) then
+					hasChildGroups = true
+				end
+			end
+		end
+	end
+
+	container:SetLayout("flow")
+	local scroll
+
+	--Add a scrollframe if we are not going to add a group control, this is the inverse of the conditions for that later on
+	if (not (hasChildGroups and not inline)) or (grouptype ~= "tab" and grouptype ~= "select" and (parenttype == "tree" and not isRoot)) then
+		if container.type ~= "InlineGroup" and container.type ~= "SimpleGroup" then
+			scroll = gui:Create("ScrollFrame")
+			scroll:SetLayout("flow")
+			scroll.width = "fill"
+			scroll.height = "fill"
+			container:SetLayout("fill")
+			container:AddChild(scroll)
+			container = scroll
+		end
+	end
+
+	FeedOptions(appName,options,container,rootframe,path,group,nil)
+
+	if scroll then
+		container:PerformLayout()
+		local status = self:GetStatusTable(appName, path)
+		if not status.scroll then
+			status.scroll = {}
+		end
+		scroll:SetStatusTable(status.scroll)
+	end
+
+	if hasChildGroups and not inline then
+		local name = GetOptionsMemberValue("name", group, options, path, appName)
+		if grouptype == "tab" then
+
+			local tab = gui:Create("TabGroup")
+			InjectInfo(tab, options, group, path, rootframe, appName)
+			tab:SetCallback("OnGroupSelected", GroupSelected)
+			tab:SetCallback("OnTabEnter", TreeOnButtonEnter)
+			tab:SetCallback("OnTabLeave", TreeOnButtonLeave)
+
+			local status = AceConfigDialog:GetStatusTable(appName, path)
+			if not status.groups then
+				status.groups = {}
+			end
+			tab:SetStatusTable(status.groups)
+			tab.width = "fill"
+			tab.height = "fill"
+
+			local tabs = BuildGroups(group, options, path, appName)
+			tab:SetTabs(tabs)
+			tab:SetUserData("tablist", tabs)
+
+			for i = 1, #tabs do
+				local entry = tabs[i]
+				if not entry.disabled then
+					tab:SelectTab((GroupExists(appName, options, path,status.groups.selected) and status.groups.selected) or entry.value)
+					break
+				end
+			end
+
+			container:AddChild(tab)
+
+		elseif grouptype == "select" then
+
+			local select = gui:Create("DropdownGroup")
+			select:SetTitle(name)
+			InjectInfo(select, options, group, path, rootframe, appName)
+			select:SetCallback("OnGroupSelected", GroupSelected)
+			local status = AceConfigDialog:GetStatusTable(appName, path)
+			if not status.groups then
+				status.groups = {}
+			end
+			select:SetStatusTable(status.groups)
+			local grouplist, orderlist = BuildSelect(group, options, path, appName)
+			select:SetGroupList(grouplist, orderlist)
+			select:SetUserData("grouplist", grouplist)
+			select:SetUserData("orderlist", orderlist)
+
+			local firstgroup = orderlist[1]
+			if firstgroup then
+				select:SetGroup((GroupExists(appName, options, path,status.groups.selected) and status.groups.selected) or firstgroup)
+			end
+
+			select.width = "fill"
+			select.height = "fill"
+
+			container:AddChild(select)
+
+		--assume tree group by default
+		--if parenttype is tree then this group is already a node on that tree
+		elseif (parenttype ~= "tree") or isRoot then
+			local tree = gui:Create("TreeGroup")
+			InjectInfo(tree, options, group, path, rootframe, appName)
+			tree:EnableButtonTooltips(false)
+
+			tree.width = "fill"
+			tree.height = "fill"
+
+			tree:SetCallback("OnGroupSelected", GroupSelected)
+			tree:SetCallback("OnButtonEnter", TreeOnButtonEnter)
+			tree:SetCallback("OnButtonLeave", TreeOnButtonLeave)
+
+			local status = AceConfigDialog:GetStatusTable(appName, path)
+			if not status.groups then
+				status.groups = {}
+			end
+			local treedefinition = BuildGroups(group, options, path, appName, true)
+			tree:SetStatusTable(status.groups)
+
+			tree:SetTree(treedefinition)
+			tree:SetUserData("tree",treedefinition)
+
+			for i = 1, #treedefinition do
+				local entry = treedefinition[i]
+				if not entry.disabled then
+					tree:SelectByValue((GroupExists(appName, options, path,status.groups.selected) and status.groups.selected) or entry.value)
+					break
+				end
+			end
+
+			container:AddChild(tree)
+		end
+	end
+end
+
+local old_CloseSpecialWindows
+
+
+local function RefreshOnUpdate(this)
+	for appName in pairs(this.closing) do
+		if AceConfigDialog.OpenFrames[appName] then
+			AceConfigDialog.OpenFrames[appName]:Hide()
+		end
+		if AceConfigDialog.BlizOptions and AceConfigDialog.BlizOptions[appName] then
+			for key, widget in pairs(AceConfigDialog.BlizOptions[appName]) do
+				if not widget:IsVisible() then
+					widget:ReleaseChildren()
+				end
+			end
+		end
+		this.closing[appName] = nil
+	end
+
+	if this.closeAll then
+		for k, v in pairs(AceConfigDialog.OpenFrames) do
+			if not this.closeAllOverride[k] then
+				v:Hide()
+			end
+		end
+		this.closeAll = nil
+		wipe(this.closeAllOverride)
+	end
+
+	for appName in pairs(this.apps) do
+		if AceConfigDialog.OpenFrames[appName] then
+			local user = AceConfigDialog.OpenFrames[appName]:GetUserDataTable()
+			AceConfigDialog:Open(appName, unpack(user.basepath or emptyTbl))
+		end
+		if AceConfigDialog.BlizOptions and AceConfigDialog.BlizOptions[appName] then
+			for key, widget in pairs(AceConfigDialog.BlizOptions[appName]) do
+				local user = widget:GetUserDataTable()
+				if widget:IsVisible() then
+					AceConfigDialog:Open(widget:GetUserData("appName"), widget, unpack(user.basepath or emptyTbl))
+				end
+			end
+		end
+		this.apps[appName] = nil
+	end
+	this:SetScript("OnUpdate", nil)
+end
+
+-- Upgrade the OnUpdate script as well, if needed.
+if AceConfigDialog.frame:GetScript("OnUpdate") then
+	AceConfigDialog.frame:SetScript("OnUpdate", RefreshOnUpdate)
+end
+
+--- Close all open options windows
+function AceConfigDialog:CloseAll()
+	AceConfigDialog.frame.closeAll = true
+	AceConfigDialog.frame:SetScript("OnUpdate", RefreshOnUpdate)
+	if next(self.OpenFrames) then
+		return true
+	end
+end
+
+--- Close a specific options window.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+function AceConfigDialog:Close(appName)
+	if self.OpenFrames[appName] then
+		AceConfigDialog.frame.closing[appName] = true
+		AceConfigDialog.frame:SetScript("OnUpdate", RefreshOnUpdate)
+		return true
+	end
+end
+
+-- Internal -- Called by AceConfigRegistry
+function AceConfigDialog:ConfigTableChanged(event, appName)
+	AceConfigDialog.frame.apps[appName] = true
+	AceConfigDialog.frame:SetScript("OnUpdate", RefreshOnUpdate)
+end
+
+reg.RegisterCallback(AceConfigDialog, "ConfigTableChange", "ConfigTableChanged")
+
+--- Sets the default size of the options window for a specific application.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param width The default width
+-- @param height The default height
+function AceConfigDialog:SetDefaultSize(appName, width, height)
+	local status = AceConfigDialog:GetStatusTable(appName)
+	if type(width) == "number" and type(height) == "number" then
+		status.width = width
+		status.height = height
+	end
+end
+
+--- Open an option window at the specified path (if any).
+-- This function can optionally feed the group into a pre-created container
+-- instead of creating a new container frame.
+-- @paramsig appName [, container][, ...]
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param container An optional container frame to feed the options into
+-- @param ... The path to open after creating the options window (see `:SelectGroup` for details)
+function AceConfigDialog:Open(appName, container, ...)
+	if not old_CloseSpecialWindows then
+		old_CloseSpecialWindows = CloseSpecialWindows
+		CloseSpecialWindows = function()
+			local found = old_CloseSpecialWindows()
+			return self:CloseAll() or found
+		end
+	end
+	local app = reg:GetOptionsTable(appName)
+	if not app then
+		error(("%s isn't registed with AceConfigRegistry, unable to open config"):format(appName), 2)
+	end
+	local options = app("dialog", MAJOR)
+
+	local f
+
+	local path = new()
+	local name = GetOptionsMemberValue("name", options, options, path, appName)
+
+	--If an optional path is specified add it to the path table before feeding the options
+	--as container is optional as well it may contain the first element of the path
+	if type(container) == "string" then
+		tinsert(path, container)
+		container = nil
+	end
+	for n = 1, select("#",...) do
+		tinsert(path, (select(n, ...)))
+	end
+
+	local option = options
+	if type(container) == "table" and container.type == "BlizOptionsGroup" and #path > 0 then
+		for i = 1, #path do
+			option = options.args[path[i]]
+		end
+		name = format("%s - %s", name, GetOptionsMemberValue("name", option, options, path, appName))
+	end
+
+	--if a container is given feed into that
+	if container then
+		f = container
+		f:ReleaseChildren()
+		f:SetUserData("appName", appName)
+		f:SetUserData("iscustom", true)
+		if #path > 0 then
+			f:SetUserData("basepath", copy(path))
+		end
+		local status = AceConfigDialog:GetStatusTable(appName)
+		if not status.width then
+			status.width =  700
+		end
+		if not status.height then
+			status.height = 500
+		end
+		if f.SetStatusTable then
+			f:SetStatusTable(status)
+		end
+		if f.SetTitle then
+			f:SetTitle(name or "")
+		end
+	else
+		if not self.OpenFrames[appName] then
+			f = gui:Create("Frame")
+			self.OpenFrames[appName] = f
+		else
+			f = self.OpenFrames[appName]
+		end
+		f:ReleaseChildren()
+		f:SetCallback("OnClose", FrameOnClose)
+		f:SetUserData("appName", appName)
+		if #path > 0 then
+			f:SetUserData("basepath", copy(path))
+		end
+		f:SetTitle(name or "")
+		local status = AceConfigDialog:GetStatusTable(appName)
+		f:SetStatusTable(status)
+	end
+
+	self:FeedGroup(appName,options,f,f,path,true)
+	if f.Show then
+		f:Show()
+	end
+	del(path)
+
+	if AceConfigDialog.frame.closeAll then
+		-- close all is set, but thats not good, since we're just opening here, so force it
+		AceConfigDialog.frame.closeAllOverride[appName] = true
+	end
+end
+
+-- convert pre-39 BlizOptions structure to the new format
+if oldminor and oldminor < 39 and AceConfigDialog.BlizOptions then
+	local old = AceConfigDialog.BlizOptions
+	local new = {}
+	for key, widget in pairs(old) do
+		local appName = widget:GetUserData("appName")
+		if not new[appName] then new[appName] = {} end
+		new[appName][key] = widget
+	end
+	AceConfigDialog.BlizOptions = new
+else
+	AceConfigDialog.BlizOptions = AceConfigDialog.BlizOptions or {}
+end
+
+local function FeedToBlizPanel(widget, event)
+	local path = widget:GetUserData("path")
+	AceConfigDialog:Open(widget:GetUserData("appName"), widget, unpack(path or emptyTbl))
+end
+
+local function ClearBlizPanel(widget, event)
+	local appName = widget:GetUserData("appName")
+	AceConfigDialog.frame.closing[appName] = true
+	AceConfigDialog.frame:SetScript("OnUpdate", RefreshOnUpdate)
+end
+
+--- Add an option table into the Blizzard Interface Options panel.
+-- You can optionally supply a descriptive name to use and a parent frame to use,
+-- as well as a path in the options table.\\
+-- If no name is specified, the appName will be used instead.
+--
+-- If you specify a proper `parent` (by name), the interface options will generate a
+-- tree layout. Note that only one level of children is supported, so the parent always
+-- has to be a head-level note.
+--
+-- This function returns a reference to the container frame registered with the Interface
+-- Options. You can use this reference to open the options with the API function
+-- `InterfaceOptionsFrame_OpenToCategory`.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param name A descriptive name to display in the options tree (defaults to appName)
+-- @param parent The parent to use in the interface options tree.
+-- @param ... The path in the options table to feed into the interface options panel.
+-- @return The reference to the frame registered into the Interface Options.
+function AceConfigDialog:AddToBlizOptions(appName, name, parent, ...)
+	local BlizOptions = AceConfigDialog.BlizOptions
+
+	local key = appName
+	for n = 1, select("#", ...) do
+		key = key.."\001"..select(n, ...)
+	end
+
+	if not BlizOptions[appName] then
+		BlizOptions[appName] = {}
+	end
+
+	if not BlizOptions[appName][key] then
+		local group = gui:Create("BlizOptionsGroup")
+		BlizOptions[appName][key] = group
+		group:SetName(name or appName, parent)
+
+		group:SetTitle(name or appName)
+		group:SetUserData("appName", appName)
+		if select("#", ...) > 0 then
+			local path = {}
+			for n = 1, select("#",...) do
+				tinsert(path, (select(n, ...)))
+			end
+			group:SetUserData("path", path)
+		end
+		group:SetCallback("OnShow", FeedToBlizPanel)
+		group:SetCallback("OnHide", ClearBlizPanel)
+		InterfaceOptions_AddCategory(group.frame)
+		return group.frame
+	else
+		error(("%s has already been added to the Blizzard Options Window with the given path"):format(appName), 2)
+	end
+end

--- a/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.xml
+++ b/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceConfigDialog-3.0.lua"/>
+</Ui>

--- a/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.lua
@@ -1,0 +1,371 @@
+--- AceConfigRegistry-3.0 handles central registration of options tables in use by addons and modules.\\
+-- Options tables can be registered as raw tables, OR as function refs that return a table.\\
+-- Such functions receive three arguments: "uiType", "uiName", "appName". \\
+-- * Valid **uiTypes**: "cmd", "dropdown", "dialog". This is verified by the library at call time. \\
+-- * The **uiName** field is expected to contain the full name of the calling addon, including version, e.g. "FooBar-1.0". This is verified by the library at call time.\\
+-- * The **appName** field is the options table name as given at registration time \\
+--
+-- :IterateOptionsTables() (and :GetOptionsTable() if only given one argument) return a function reference that the requesting config handling addon must call with valid "uiType", "uiName".
+-- @class file
+-- @name AceConfigRegistry-3.0
+-- @release $Id: AceConfigRegistry-3.0.lua 1207 2019-06-23 12:08:33Z nevcairiel $
+local CallbackHandler = LibStub("CallbackHandler-1.0")
+
+local MAJOR, MINOR = "AceConfigRegistry-3.0", 20
+local AceConfigRegistry = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceConfigRegistry then return end
+
+AceConfigRegistry.tables = AceConfigRegistry.tables or {}
+
+if not AceConfigRegistry.callbacks then
+	AceConfigRegistry.callbacks = CallbackHandler:New(AceConfigRegistry)
+end
+
+-- Lua APIs
+local tinsert, tconcat = table.insert, table.concat
+local strfind, strmatch = string.find, string.match
+local type, tostring, select, pairs = type, tostring, select, pairs
+local error, assert = error, assert
+
+-----------------------------------------------------------------------
+-- Validating options table consistency:
+
+
+AceConfigRegistry.validated = {
+	-- list of options table names ran through :ValidateOptionsTable automatically.
+	-- CLEARED ON PURPOSE, since newer versions may have newer validators
+	cmd = {},
+	dropdown = {},
+	dialog = {},
+}
+
+
+
+local function err(msg, errlvl, ...)
+	local t = {}
+	for i=select("#",...),1,-1 do
+		tinsert(t, (select(i, ...)))
+	end
+	error(MAJOR..":ValidateOptionsTable(): "..tconcat(t,".")..msg, errlvl+2)
+end
+
+
+local isstring={["string"]=true, _="string"}
+local isstringfunc={["string"]=true,["function"]=true, _="string or funcref"}
+local istable={["table"]=true,   _="table"}
+local ismethodtable={["table"]=true,["string"]=true,["function"]=true,   _="methodname, funcref or table"}
+local optstring={["nil"]=true,["string"]=true, _="string"}
+local optstringfunc={["nil"]=true,["string"]=true,["function"]=true, _="string or funcref"}
+local optstringnumberfunc={["nil"]=true,["string"]=true,["number"]=true,["function"]=true, _="string, number or funcref"}
+local optnumber={["nil"]=true,["number"]=true, _="number"}
+local optmethodfalse={["nil"]=true,["string"]=true,["function"]=true,["boolean"]={[false]=true},  _="methodname, funcref or false"}
+local optmethodnumber={["nil"]=true,["string"]=true,["function"]=true,["number"]=true,  _="methodname, funcref or number"}
+local optmethodtable={["nil"]=true,["string"]=true,["function"]=true,["table"]=true,  _="methodname, funcref or table"}
+local optmethodbool={["nil"]=true,["string"]=true,["function"]=true,["boolean"]=true,  _="methodname, funcref or boolean"}
+local opttable={["nil"]=true,["table"]=true,  _="table"}
+local optbool={["nil"]=true,["boolean"]=true,  _="boolean"}
+local optboolnumber={["nil"]=true,["boolean"]=true,["number"]=true,  _="boolean or number"}
+local optstringnumber={["nil"]=true,["string"]=true,["number"]=true, _="string or number"}
+
+local basekeys={
+	type=isstring,
+	name=isstringfunc,
+	desc=optstringfunc,
+	descStyle=optstring,
+	order=optmethodnumber,
+	validate=optmethodfalse,
+	confirm=optmethodbool,
+	confirmText=optstring,
+	disabled=optmethodbool,
+	hidden=optmethodbool,
+		guiHidden=optmethodbool,
+		dialogHidden=optmethodbool,
+		dropdownHidden=optmethodbool,
+	cmdHidden=optmethodbool,
+	icon=optstringnumberfunc,
+	iconCoords=optmethodtable,
+	handler=opttable,
+	get=optmethodfalse,
+	set=optmethodfalse,
+	func=optmethodfalse,
+	arg={["*"]=true},
+	width=optstringnumber,
+}
+
+local typedkeys={
+	header={
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	description={
+		image=optstringnumberfunc,
+		imageCoords=optmethodtable,
+		imageHeight=optnumber,
+		imageWidth=optnumber,
+		fontSize=optstringfunc,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	group={
+		args=istable,
+		plugins=opttable,
+		inline=optbool,
+			cmdInline=optbool,
+			guiInline=optbool,
+			dropdownInline=optbool,
+			dialogInline=optbool,
+		childGroups=optstring,
+	},
+	execute={
+		image=optstringnumberfunc,
+		imageCoords=optmethodtable,
+		imageHeight=optnumber,
+		imageWidth=optnumber,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	input={
+		pattern=optstring,
+		usage=optstring,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+		multiline=optboolnumber,
+	},
+	toggle={
+		tristate=optbool,
+		image=optstringnumberfunc,
+		imageCoords=optmethodtable,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	tristate={
+	},
+	range={
+		min=optnumber,
+		softMin=optnumber,
+		max=optnumber,
+		softMax=optnumber,
+		step=optnumber,
+		bigStep=optnumber,
+		isPercent=optbool,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	select={
+		values=ismethodtable,
+		sorting=optmethodtable,
+		style={
+			["nil"]=true,
+			["string"]={dropdown=true,radio=true},
+			_="string: 'dropdown' or 'radio'"
+		},
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+		itemControl=optstring,
+	},
+	multiselect={
+		values=ismethodtable,
+		style=optstring,
+		tristate=optbool,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	color={
+		hasAlpha=optmethodbool,
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+	keybinding={
+		control=optstring,
+		dialogControl=optstring,
+		dropdownControl=optstring,
+	},
+}
+
+local function validateKey(k,errlvl,...)
+	errlvl=(errlvl or 0)+1
+	if type(k)~="string" then
+		err("["..tostring(k).."] - key is not a string", errlvl,...)
+	end
+	if strfind(k, "[%c\127]") then
+		err("["..tostring(k).."] - key name contained control characters", errlvl,...)
+	end
+end
+
+local function validateVal(v, oktypes, errlvl,...)
+	errlvl=(errlvl or 0)+1
+	local isok=oktypes[type(v)] or oktypes["*"]
+
+	if not isok then
+		err(": expected a "..oktypes._..", got '"..tostring(v).."'", errlvl,...)
+	end
+	if type(isok)=="table" then		-- isok was a table containing specific values to be tested for!
+		if not isok[v] then
+			err(": did not expect "..type(v).." value '"..tostring(v).."'", errlvl,...)
+		end
+	end
+end
+
+local function validate(options,errlvl,...)
+	errlvl=(errlvl or 0)+1
+	-- basic consistency
+	if type(options)~="table" then
+		err(": expected a table, got a "..type(options), errlvl,...)
+	end
+	if type(options.type)~="string" then
+		err(".type: expected a string, got a "..type(options.type), errlvl,...)
+	end
+
+	-- get type and 'typedkeys' member
+	local tk = typedkeys[options.type]
+	if not tk then
+		err(".type: unknown type '"..options.type.."'", errlvl,...)
+	end
+
+	-- make sure that all options[] are known parameters
+	for k,v in pairs(options) do
+		if not (tk[k] or basekeys[k]) then
+			err(": unknown parameter", errlvl,tostring(k),...)
+		end
+	end
+
+	-- verify that required params are there, and that everything is the right type
+	for k,oktypes in pairs(basekeys) do
+		validateVal(options[k], oktypes, errlvl,k,...)
+	end
+	for k,oktypes in pairs(tk) do
+		validateVal(options[k], oktypes, errlvl,k,...)
+	end
+
+	-- extra logic for groups
+	if options.type=="group" then
+		for k,v in pairs(options.args) do
+			validateKey(k,errlvl,"args",...)
+			validate(v, errlvl,k,"args",...)
+		end
+		if options.plugins then
+			for plugname,plugin in pairs(options.plugins) do
+				if type(plugin)~="table" then
+					err(": expected a table, got '"..tostring(plugin).."'", errlvl,tostring(plugname),"plugins",...)
+				end
+				for k,v in pairs(plugin) do
+					validateKey(k,errlvl,tostring(plugname),"plugins",...)
+					validate(v, errlvl,k,tostring(plugname),"plugins",...)
+				end
+			end
+		end
+	end
+end
+
+
+--- Validates basic structure and integrity of an options table \\
+-- Does NOT verify that get/set etc actually exist, since they can be defined at any depth
+-- @param options The table to be validated
+-- @param name The name of the table to be validated (shown in any error message)
+-- @param errlvl (optional number) error level offset, default 0 (=errors point to the function calling :ValidateOptionsTable)
+function AceConfigRegistry:ValidateOptionsTable(options,name,errlvl)
+	errlvl=(errlvl or 0)+1
+	name = name or "Optionstable"
+	if not options.name then
+		options.name=name	-- bit of a hack, the root level doesn't really need a .name :-/
+	end
+	validate(options,errlvl,name)
+end
+
+--- Fires a "ConfigTableChange" callback for those listening in on it, allowing config GUIs to refresh.
+-- You should call this function if your options table changed from any outside event, like a game event
+-- or a timer.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+function AceConfigRegistry:NotifyChange(appName)
+	if not AceConfigRegistry.tables[appName] then return end
+	AceConfigRegistry.callbacks:Fire("ConfigTableChange", appName)
+end
+
+-- -------------------------------------------------------------------
+-- Registering and retreiving options tables:
+
+
+-- validateGetterArgs: helper function for :GetOptionsTable (or, rather, the getter functions returned by it)
+
+local function validateGetterArgs(uiType, uiName, errlvl)
+	errlvl=(errlvl or 0)+2
+	if uiType~="cmd" and uiType~="dropdown" and uiType~="dialog" then
+		error(MAJOR..": Requesting options table: 'uiType' - invalid configuration UI type, expected 'cmd', 'dropdown' or 'dialog'", errlvl)
+	end
+	if not strmatch(uiName, "[A-Za-z]%-[0-9]") then	-- Expecting e.g. "MyLib-1.2"
+		error(MAJOR..": Requesting options table: 'uiName' - badly formatted or missing version number. Expected e.g. 'MyLib-1.2'", errlvl)
+	end
+end
+
+--- Register an options table with the config registry.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param options The options table, OR a function reference that generates it on demand. \\
+-- See the top of the page for info on arguments passed to such functions.
+-- @param skipValidation Skip options table validation (primarily useful for extremely huge options, with a noticeable slowdown)
+function AceConfigRegistry:RegisterOptionsTable(appName, options, skipValidation)
+	if type(options)=="table" then
+		if options.type~="group" then	-- quick sanity checker
+			error(MAJOR..": RegisterOptionsTable(appName, options): 'options' - missing type='group' member in root group", 2)
+		end
+		AceConfigRegistry.tables[appName] = function(uiType, uiName, errlvl)
+			errlvl=(errlvl or 0)+1
+			validateGetterArgs(uiType, uiName, errlvl)
+			if not AceConfigRegistry.validated[uiType][appName] and not skipValidation then
+				AceConfigRegistry:ValidateOptionsTable(options, appName, errlvl)	-- upgradable
+				AceConfigRegistry.validated[uiType][appName] = true
+			end
+			return options
+		end
+	elseif type(options)=="function" then
+		AceConfigRegistry.tables[appName] = function(uiType, uiName, errlvl)
+			errlvl=(errlvl or 0)+1
+			validateGetterArgs(uiType, uiName, errlvl)
+			local tab = assert(options(uiType, uiName, appName))
+			if not AceConfigRegistry.validated[uiType][appName] and not skipValidation then
+				AceConfigRegistry:ValidateOptionsTable(tab, appName, errlvl)	-- upgradable
+				AceConfigRegistry.validated[uiType][appName] = true
+			end
+			return tab
+		end
+	else
+		error(MAJOR..": RegisterOptionsTable(appName, options): 'options' - expected table or function reference", 2)
+	end
+end
+
+--- Returns an iterator of ["appName"]=funcref pairs
+function AceConfigRegistry:IterateOptionsTables()
+	return pairs(AceConfigRegistry.tables)
+end
+
+
+
+
+--- Query the registry for a specific options table.
+-- If only appName is given, a function is returned which you
+-- can call with (uiType,uiName) to get the table.\\
+-- If uiType&uiName are given, the table is returned.
+-- @param appName The application name as given to `:RegisterOptionsTable()`
+-- @param uiType The type of UI to get the table for, one of "cmd", "dropdown", "dialog"
+-- @param uiName The name of the library/addon querying for the table, e.g. "MyLib-1.0"
+function AceConfigRegistry:GetOptionsTable(appName, uiType, uiName)
+	local f = AceConfigRegistry.tables[appName]
+	if not f then
+		return nil
+	end
+
+	if uiType then
+		return f(uiType,uiName,1)	-- get the table for us
+	else
+		return f	-- return the function
+	end
+end

--- a/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.xml
+++ b/Libs/AceConfig-3.0/AceConfigRegistry-3.0/AceConfigRegistry-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceConfigRegistry-3.0.lua"/>
+</Ui>

--- a/Libs/AceConsole-3.0/AceConsole-3.0.lua
+++ b/Libs/AceConsole-3.0/AceConsole-3.0.lua
@@ -1,0 +1,250 @@
+--- **AceConsole-3.0** provides registration facilities for slash commands.
+-- You can register slash commands to your custom functions and use the `GetArgs` function to parse them
+-- to your addons individual needs.
+--
+-- **AceConsole-3.0** can be embeded into your addon, either explicitly by calling AceConsole:Embed(MyAddon) or by
+-- specifying it as an embeded library in your AceAddon. All functions will be available on your addon object
+-- and can be accessed directly, without having to explicitly call AceConsole itself.\\
+-- It is recommended to embed AceConsole, otherwise you'll have to specify a custom `self` on all calls you
+-- make into AceConsole.
+-- @class file
+-- @name AceConsole-3.0
+-- @release $Id: AceConsole-3.0.lua 1202 2019-05-15 23:11:22Z nevcairiel $
+local MAJOR,MINOR = "AceConsole-3.0", 7
+
+local AceConsole, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceConsole then return end -- No upgrade needed
+
+AceConsole.embeds = AceConsole.embeds or {} -- table containing objects AceConsole is embedded in.
+AceConsole.commands = AceConsole.commands or {} -- table containing commands registered
+AceConsole.weakcommands = AceConsole.weakcommands or {} -- table containing self, command => func references for weak commands that don't persist through enable/disable
+
+-- Lua APIs
+local tconcat, tostring, select = table.concat, tostring, select
+local type, pairs, error = type, pairs, error
+local format, strfind, strsub = string.format, string.find, string.sub
+local max = math.max
+
+-- WoW APIs
+local _G = _G
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: DEFAULT_CHAT_FRAME, SlashCmdList, hash_SlashCmdList
+
+local tmp={}
+local function Print(self,frame,...)
+	local n=0
+	if self ~= AceConsole then
+		n=n+1
+		tmp[n] = "|cff33ff99"..tostring( self ).."|r:"
+	end
+	for i=1, select("#", ...) do
+		n=n+1
+		tmp[n] = tostring(select(i, ...))
+	end
+	frame:AddMessage( tconcat(tmp," ",1,n) )
+end
+
+--- Print to DEFAULT_CHAT_FRAME or given ChatFrame (anything with an .AddMessage function)
+-- @paramsig [chatframe ,] ...
+-- @param chatframe Custom ChatFrame to print to (or any frame with an .AddMessage function)
+-- @param ... List of any values to be printed
+function AceConsole:Print(...)
+	local frame = ...
+	if type(frame) == "table" and frame.AddMessage then	-- Is first argument something with an .AddMessage member?
+		return Print(self, frame, select(2,...))
+	else
+		return Print(self, DEFAULT_CHAT_FRAME, ...)
+	end
+end
+
+
+--- Formatted (using format()) print to DEFAULT_CHAT_FRAME or given ChatFrame (anything with an .AddMessage function)
+-- @paramsig [chatframe ,] "format"[, ...]
+-- @param chatframe Custom ChatFrame to print to (or any frame with an .AddMessage function)
+-- @param format Format string - same syntax as standard Lua format()
+-- @param ... Arguments to the format string
+function AceConsole:Printf(...)
+	local frame = ...
+	if type(frame) == "table" and frame.AddMessage then	-- Is first argument something with an .AddMessage member?
+		return Print(self, frame, format(select(2,...)))
+	else
+		return Print(self, DEFAULT_CHAT_FRAME, format(...))
+	end
+end
+
+
+
+
+--- Register a simple chat command
+-- @param command Chat command to be registered WITHOUT leading "/"
+-- @param func Function to call when the slash command is being used (funcref or methodname)
+-- @param persist if false, the command will be soft disabled/enabled when aceconsole is used as a mixin (default: true)
+function AceConsole:RegisterChatCommand( command, func, persist )
+	if type(command)~="string" then error([[Usage: AceConsole:RegisterChatCommand( "command", func[, persist ]): 'command' - expected a string]], 2) end
+
+	if persist==nil then persist=true end	-- I'd rather have my addon's "/addon enable" around if the author screws up. Having some extra slash regged when it shouldnt be isn't as destructive. True is a better default. /Mikk
+
+	local name = "ACECONSOLE_"..command:upper()
+
+	if type( func ) == "string" then
+		SlashCmdList[name] = function(input, editBox)
+			self[func](self, input, editBox)
+		end
+	else
+		SlashCmdList[name] = func
+	end
+	_G["SLASH_"..name.."1"] = "/"..command:lower()
+	AceConsole.commands[command] = name
+	-- non-persisting commands are registered for enabling disabling
+	if not persist then
+		if not AceConsole.weakcommands[self] then AceConsole.weakcommands[self] = {} end
+		AceConsole.weakcommands[self][command] = func
+	end
+	return true
+end
+
+--- Unregister a chatcommand
+-- @param command Chat command to be unregistered WITHOUT leading "/"
+function AceConsole:UnregisterChatCommand( command )
+	local name = AceConsole.commands[command]
+	if name then
+		SlashCmdList[name] = nil
+		_G["SLASH_" .. name .. "1"] = nil
+		hash_SlashCmdList["/" .. command:upper()] = nil
+		AceConsole.commands[command] = nil
+	end
+end
+
+--- Get an iterator over all Chat Commands registered with AceConsole
+-- @return Iterator (pairs) over all commands
+function AceConsole:IterateChatCommands() return pairs(AceConsole.commands) end
+
+
+local function nils(n, ...)
+	if n>1 then
+		return nil, nils(n-1, ...)
+	elseif n==1 then
+		return nil, ...
+	else
+		return ...
+	end
+end
+
+
+--- Retreive one or more space-separated arguments from a string.
+-- Treats quoted strings and itemlinks as non-spaced.
+-- @param str The raw argument string
+-- @param numargs How many arguments to get (default 1)
+-- @param startpos Where in the string to start scanning (default  1)
+-- @return Returns arg1, arg2, ..., nextposition\\
+-- Missing arguments will be returned as nils. 'nextposition' is returned as 1e9 at the end of the string.
+function AceConsole:GetArgs(str, numargs, startpos)
+	numargs = numargs or 1
+	startpos = max(startpos or 1, 1)
+
+	local pos=startpos
+
+	-- find start of new arg
+	pos = strfind(str, "[^ ]", pos)
+	if not pos then	-- whoops, end of string
+		return nils(numargs, 1e9)
+	end
+
+	if numargs<1 then
+		return pos
+	end
+
+	-- quoted or space separated? find out which pattern to use
+	local delim_or_pipe
+	local ch = strsub(str, pos, pos)
+	if ch=='"' then
+		pos = pos + 1
+		delim_or_pipe='([|"])'
+	elseif ch=="'" then
+		pos = pos + 1
+		delim_or_pipe="([|'])"
+	else
+		delim_or_pipe="([| ])"
+	end
+
+	startpos = pos
+
+	while true do
+		-- find delimiter or hyperlink
+		local ch,_
+		pos,_,ch = strfind(str, delim_or_pipe, pos)
+
+		if not pos then break end
+
+		if ch=="|" then
+			-- some kind of escape
+
+			if strsub(str,pos,pos+1)=="|H" then
+				-- It's a |H....|hhyper link!|h
+				pos=strfind(str, "|h", pos+2)	-- first |h
+				if not pos then break end
+
+				pos=strfind(str, "|h", pos+2)	-- second |h
+				if not pos then break end
+			elseif strsub(str,pos, pos+1) == "|T" then
+				-- It's a |T....|t  texture
+				pos=strfind(str, "|t", pos+2)
+				if not pos then break end
+			end
+
+			pos=pos+2 -- skip past this escape (last |h if it was a hyperlink)
+
+		else
+			-- found delimiter, done with this arg
+			return strsub(str, startpos, pos-1), AceConsole:GetArgs(str, numargs-1, pos+1)
+		end
+
+	end
+
+	-- search aborted, we hit end of string. return it all as one argument. (yes, even if it's an unterminated quote or hyperlink)
+	return strsub(str, startpos), nils(numargs-1, 1e9)
+end
+
+
+--- embedding and embed handling
+
+local mixins = {
+	"Print",
+	"Printf",
+	"RegisterChatCommand",
+	"UnregisterChatCommand",
+	"GetArgs",
+}
+
+-- Embeds AceConsole into the target object making the functions from the mixins list available on target:..
+-- @param target target object to embed AceBucket in
+function AceConsole:Embed( target )
+	for k, v in pairs( mixins ) do
+		target[v] = self[v]
+	end
+	self.embeds[target] = true
+	return target
+end
+
+function AceConsole:OnEmbedEnable( target )
+	if AceConsole.weakcommands[target] then
+		for command, func in pairs( AceConsole.weakcommands[target] ) do
+			target:RegisterChatCommand( command, func, false, true ) -- nonpersisting and silent registry
+		end
+	end
+end
+
+function AceConsole:OnEmbedDisable( target )
+	if AceConsole.weakcommands[target] then
+		for command, func in pairs( AceConsole.weakcommands[target] ) do
+			target:UnregisterChatCommand( command ) -- TODO: this could potentially unregister a command from another application in case of command conflicts. Do we care?
+		end
+	end
+end
+
+for addon in pairs(AceConsole.embeds) do
+	AceConsole:Embed(addon)
+end

--- a/Libs/AceConsole-3.0/AceConsole-3.0.xml
+++ b/Libs/AceConsole-3.0/AceConsole-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceConsole-3.0.lua"/>
+</Ui>

--- a/embeds.xml
+++ b/embeds.xml
@@ -4,6 +4,8 @@
   <Include file="Libs\LibDataBroker-1.1\LibDataBroker-1.1.lua"/>
   <Include file="Libs\AceAddon-3.0\AceAddon-3.0.xml"/>
   <Include file="Libs\AceGUI-3.0\AceGUI-3.0.xml"/>
+  <Include file="Libs\AceConsole-3.0\AceConsole-3.0.xml"/>
+  <Include file="Libs\AceConfig-3.0\AceConfig-3.0.xml"/>
   <Include file="Libs\LibDBIcon-1.0\LibDBIcon-1.0\lib.xml"/>
   <Include file="Libs\ChatThrottleLib.lua"/>
 </Ui>


### PR DESCRIPTION
Basic interface options use Ace3.  There aren't many options yet so its a bit empty but I added a couple of extra if we decide on wanting them.  I expect with some of the future features that this will fill out

![image](https://user-images.githubusercontent.com/9808893/149610342-e0e1a179-d362-4790-98a4-4de935f934b9.png)


* Filter F's in chat (lame! but I've seen some streamers request this). 
* Show version numbers in chat.  This has been helpful for me in helping people figure out if they are on the right version or not, but it is less necessary now that everyone is getting used to the addon
* Users can now move the alert frame and scale
* death alerts and grief alert settings added to interface options