### PR TITLE
Failing because not even text lines covered

### DIFF
--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -16,10 +16,9 @@ local Combine = {
     6120, 6121, 6122, 6123, 6124, 6125, 6126, 6127, 6129, 6134, 6135, 6136, 6137, 6138, 6139, 6140, 6144, 12282, 20891,
     20892, 20893, 20894, 20895, 20896, 20897, 20898, 20899, 20900, 20901, 20978, 20982, 23322, 23344, 23345, 23346, 23347,
     23348, 23473, 23474, 23475, 23476, 23477, 23478, 23479, 24143, 24145, 24146, 25861, 28979, 49778, 50055, 50057, 34652,
-    34656, 34651, 34655, 34648, 34650, 34653, 34659, 34649, 34657, 34658, 38147, 38707
+    34656, 34651, 34655, 34648, 34650, 34653, 34659, 34649, 34657, 34658, 38147, 38707, 52021, 41165, 52020, 41164, 10512,
+    15997, 23772, 10513, 8067, 8069, 8068
 }
-
-
 -- Registers
 function self_made_achievement:Register(fail_function_executor)
     self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
@@ -32,6 +31,7 @@ function self_made_achievement:Unregister()
     self:RegisterEvent("ITEM_UNLOCKED")
 end
 
+-- Check Starting gear function
 local function Start(a)
     local item_id = GetInventoryItemID("player", a)
     for index, value in ipairs(Combine) do
@@ -44,6 +44,7 @@ local function Start(a)
     return false
 end
 
+--Check if the item is selfMade
 local function isSelfCreated(...)
     for i = 1, select("#", GameTooltip:GetRegions()) do
         local region = select(i, GameTooltip:GetRegions())
@@ -73,7 +74,18 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             print("You put on a tabard! You're Stylish.")
             return
         end
-    elseif event == "ITEM_UNLOCKED" and arg[2] == nil then -- need to ensure that arg[2] is nil because it is only nil when a bag is being put into the bag "CheckBox" on the action bar.
+        if GetInventoryItemID("player", 0) ~= nil then
+            local item_id = GetInventoryItemID("player", 0)
+            local item_name, _, _, _, _, _, item_subtype = GetItemInfo(item_id)
+            for index, value in ipairs(Combine) do
+                if string.match(value, item_id) then
+                    return
+                end
+            end
+            Hardcore:Print("Equipped ammo " .. item_name .. " which isn't self created.")
+            self_made_achievement.fail_function_executor.Fail(self_made_achievement.name)
+        end
+    elseif event == "ITEM_UNLOCKED" and arg[2] == nil and arg[1] ~= 19 then -- checking for nil as it will be that way for gear swap and bag swap, checking for slot 19 as that is the tabard.
         local item_id = GetInventoryItemID("player", arg[1])
         local item_name, _, _, _, _, _, item_subtype = GetItemInfo(item_id)
         GameTooltip:SetInventoryItem("player", arg[1]) -- this arg[1] passes the invSlot to  be checked.
@@ -82,7 +94,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             if item_subtype ~= "Fishing Poles" then
                 if Start(arg[1]) == false then
                     Hardcore:Print("Equipped " .. item_name .. " which isn't self created.")
-                    --self_made_achievement.fail_function_executor.Fail(self_made_achievement.name)
+                    self_made_achievement.fail_function_executor.Fail(self_made_achievement.name)
                 end
             end
         end

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -46,6 +46,7 @@ local function Start(a)
 end
 local function isSelfCreated(...)
     local v = GameTooltip:GetRegions()
+	local totRegions = select("#", GameTooltip:GetRegions())
     for i = 1, select("#", GameTooltip:GetRegions()) do
         local region = select(i, GameTooltip:GetRegions())
         if region and region:GetObjectType() == "FontString" then
@@ -56,7 +57,7 @@ local function isSelfCreated(...)
                     return true
                 end
             end
-            if i >= 36 then -- this ensures that the loop ends, was set too low, now set to total number of regions in the tooltip
+            if i == totRegions then -- this ensures that the loop ends, was set too low, now set to total number of regions in the tooltip
                 if text == nil then
                     GameTooltip:Hide() --prevents a hung empty tooltip window
                     return false

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -9,7 +9,7 @@ self_made_achievement.title = "Self-Made"
 self_made_achievement.class = "All"
 self_made_achievement.icon_path = "Interface\\Addons\\Hardcore\\Media\\icon_self_made.blp"
 self_made_achievement.description =
-"Complete the Hardcore challenge without at any point equipping an item that you have not crafted yourself. Items your character has conjured (e.g. Firestones) are considered crafted. No items bought, dropped, or rewarded by quests are allowed to be equipped, fishing poles MAY be equipped, starting items MAY be re-equipped if taken off (items provided for a quest can be equipped). The items your character starts with are allowed to be equipped. Bags are equipped items."
+"Complete the Hardcore challenge without at any point equipping an item that you have not crafted yourself. Items your character has conjured (e.g. Firestones) are considered crafted. No items bought, dropped, or rewarded by quests are allowed to be equipped, fishing poles MAY be equipped. The items your character starts with are allowed to be equipped. Bags are equipped items."
 local Combine = {
     35, 36, 38, 39, 40, 43, 44, 45, 47, 48, 49, 51, 52, 53, 55, 56, 57, 59, 120, 121, 127, 129, 139, 140, 147, 148, 153,
     154, 1395, 1396, 2092, 2105, 2361, 2362, 2504, 2508, 2512, 2516, 2947, 3111, 3661, 6096, 6097, 6098, 6117, 6118, 6119,
@@ -35,19 +35,16 @@ end
 local function Start(a)
     local item_id = GetInventoryItemID("player", a)
     for index, value in ipairs(Combine) do
-        if string.match(item_id, value) then
+        if string.match(value, item_id) then
             GameTooltip:Hide() --prevents a hung empty tooltip window
             return true
-        elseif index == #Combine then
-            GameTooltip:Hide() --prevents a hung empty tooltip window
-            return false
         end
     end
+    GameTooltip:Hide() --prevents a hung empty tooltip window
+    return false
 end
 
 local function isSelfCreated(...)
-    local v = GameTooltip:GetRegions()
-    local totRegions = select("#", GameTooltip:GetRegions())
     for i = 1, select("#", GameTooltip:GetRegions()) do
         local region = select(i, GameTooltip:GetRegions())
         if region and region:GetObjectType() == "FontString" then
@@ -58,19 +55,11 @@ local function isSelfCreated(...)
                     return true
                 end
             end
-            if i == totRegions then -- this ensures that the loop ends
-                if text == nil then
-                    GameTooltip:Hide() --prevents a hung empty tooltip window
-                    return false
-                end
-            end
         end
     end
+    GameTooltip:Hide() --prevents a hung empty tooltip window
+    return false
 end
-
---end
-
---end
 
 -- Register Definitions
 self_made_achievement:SetScript("OnEvent", function(self, event, ...)
@@ -81,7 +70,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             return
         end
         if arg[1] == 19 then -- This is checking if what you have equipped is a tabard, we cant make those :D
-            print("You put on a tabard! You're Stylish!")
+            print("You put on a tabard! You're Stylish.")
             return
         end
     elseif event == "ITEM_UNLOCKED" and arg[2] == nil then -- need to ensure that arg[2] is nil because it is only nil when a bag is being put into the bag "CheckBox" on the action bar.
@@ -93,7 +82,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             if item_subtype ~= "Fishing Poles" then
                 if Start(arg[1]) == false then
                     Hardcore:Print("Equipped " .. item_name .. " which isn't self created.")
-                    self_made_achievement.fail_function_executor.Fail(self_made_achievement.name)
+                    --self_made_achievement.fail_function_executor.Fail(self_made_achievement.name)
                 end
             end
         end

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -19,6 +19,7 @@ local Combine = {
     34656, 34651, 34655, 34648, 34650, 34653, 34659, 34649, 34657, 34658, 38147, 38707, 52021, 41165, 52020, 41164, 10512,
     15997, 23772, 10513, 8067, 8069, 8068
 }
+
 -- Registers
 function self_made_achievement:Register(fail_function_executor)
     self:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
@@ -28,7 +29,7 @@ end
 
 function self_made_achievement:Unregister()
     self:UnregisterEvent("PLAYER_EQUIPMENT_CHANGED")
-    self:RegisterEvent("ITEM_UNLOCKED")
+    self:UnregisterEvent("ITEM_UNLOCKED")
 end
 
 -- Check Starting gear function
@@ -79,6 +80,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             local item_name, _, _, _, _, _, item_subtype = GetItemInfo(item_id)
             for index, value in ipairs(Combine) do
                 if string.match(value, item_id) then
+                    print("You made this ammo: ", item_name)
                     return
                 end
             end
@@ -90,7 +92,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
         local item_name, _, _, _, _, _, item_subtype = GetItemInfo(item_id)
         GameTooltip:SetInventoryItem("player", arg[1]) -- this arg[1] passes the invSlot to  be checked.
         -- Should these checks fail, the player fails the achievement.
-        if isSelfCreated(GameTooltip:GetRegions(arg[1])) == false then
+        if isSelfCreated(GameTooltip:GetRegions()) == false then
             if item_subtype ~= "Fishing Poles" then
                 if Start(arg[1]) == false then
                     Hardcore:Print("Equipped " .. item_name .. " which isn't self created.")

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -81,7 +81,7 @@ self_made_achievement:SetScript("OnEvent", function(self, event, ...)
             return
         end
         if arg[1] == 19 then -- This is checking if what you have equipped is a tabard, we cant make those :D
-            print("You put on a tabard! Your Stylish.")
+            print("You put on a tabard! You're Stylish!")
             return
         end
     elseif event == "ITEM_UNLOCKED" and arg[2] == nil then -- need to ensure that arg[2] is nil because it is only nil when a bag is being put into the bag "CheckBox" on the action bar.

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -44,7 +44,6 @@ local function Start(a)
         end
     end
 end
-
 local function isSelfCreated(...)
     local v = GameTooltip:GetRegions()
     for i = 1, select("#", GameTooltip:GetRegions()) do
@@ -57,7 +56,7 @@ local function isSelfCreated(...)
                     return true
                 end
             end
-            if i >= 18 then -- this ensures that the loop ends
+            if i >= 36 then -- this ensures that the loop ends, was set too low, now set to total number of regions in the tooltip
                 if text == nil then
                     GameTooltip:Hide() --prevents a hung empty tooltip window
                     return false
@@ -65,7 +64,6 @@ local function isSelfCreated(...)
             end
         end
     end
-
 end
 
 -- Register Definitions

--- a/Achievements/SelfMade.lua
+++ b/Achievements/SelfMade.lua
@@ -36,17 +36,18 @@ local function Start(a)
     local item_id = GetInventoryItemID("player", a)
     for index, value in ipairs(Combine) do
         if string.match(item_id, value) then
-            GameTooltip:Hide()--prevents a hung empty tooltip window
+            GameTooltip:Hide() --prevents a hung empty tooltip window
             return true
         elseif index == #Combine then
-            GameTooltip:Hide()--prevents a hung empty tooltip window
+            GameTooltip:Hide() --prevents a hung empty tooltip window
             return false
         end
     end
 end
+
 local function isSelfCreated(...)
     local v = GameTooltip:GetRegions()
-	local totRegions = select("#", GameTooltip:GetRegions())
+    local totRegions = select("#", GameTooltip:GetRegions())
     for i = 1, select("#", GameTooltip:GetRegions()) do
         local region = select(i, GameTooltip:GetRegions())
         if region and region:GetObjectType() == "FontString" then
@@ -57,7 +58,7 @@ local function isSelfCreated(...)
                     return true
                 end
             end
-            if i == totRegions then -- this ensures that the loop ends, was set too low, now set to total number of regions in the tooltip
+            if i == totRegions then -- this ensures that the loop ends
                 if text == nil then
                     GameTooltip:Hide() --prevents a hung empty tooltip window
                     return false
@@ -67,19 +68,27 @@ local function isSelfCreated(...)
     end
 end
 
+--end
+
+--end
+
 -- Register Definitions
 self_made_achievement:SetScript("OnEvent", function(self, event, ...)
     GameTooltip:SetOwner(WorldFrame, "ANCHOR_CURSOR") -- Anchors the cursor so it ensure we check the right tooltip
     local arg = { ... }
     if event == "PLAYER_EQUIPMENT_CHANGED" then
-        if arg[2] == true then -- this are is checking if the equippable spot is nil
+        if arg[2] == true then -- this arg[2] is checking if the equippable spot is nil
+            return
+        end
+        if arg[1] == 19 then -- This is checking if what you have equipped is a tabard, we cant make those :D
+            print("You put on a tabard! Your Stylish.")
             return
         end
     elseif event == "ITEM_UNLOCKED" and arg[2] == nil then -- need to ensure that arg[2] is nil because it is only nil when a bag is being put into the bag "CheckBox" on the action bar.
         local item_id = GetInventoryItemID("player", arg[1])
         local item_name, _, _, _, _, _, item_subtype = GetItemInfo(item_id)
         GameTooltip:SetInventoryItem("player", arg[1]) -- this arg[1] passes the invSlot to  be checked.
-	-- Should these checks fail, the player fails the achievement.
+        -- Should these checks fail, the player fails the achievement.
         if isSelfCreated(GameTooltip:GetRegions(arg[1])) == false then
             if item_subtype ~= "Fishing Poles" then
                 if Start(arg[1]) == false then


### PR DESCRIPTION
Failed the achievement when equipping and item with additional abilities on the gear like "Equip: Improves Critical Strike Rating by 3". Because it increased the amount of regions it needed to cycle through. increased i >= 36 to 36 because that is the total number of regions returned by select("#", GameTooltip:GetRegions()), so we should never go over that number and we should cover all the lines of tooltip text.