### PR TITLE
Prevent illegal trades

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -893,6 +893,13 @@ end
 TradeFrameTradeButton:SetScript("OnClick", function()
 	local duo_trio_partner = false
 	local target_trader = TradeFrameRecipientNameText:GetText()
+	local level = UnitLevel("player")
+	local max_level = 60
+	if (Hardcore_Character.game_version ~= "") and
+	   (Hardcore_Character.game_version ~= "Era") and
+	   (Hardcore_Character.game_version ~= "SoM") then
+		max_level = 80
+	end
 	if Hardcore_Character.team ~= nil then
 		for _, name in ipairs(Hardcore_Character.team) do
 			if target_trader == name then
@@ -904,7 +911,12 @@ TradeFrameTradeButton:SetScript("OnClick", function()
 	if duo_trio_partner == true then
         AcceptTrade()        
     else
-        Hardcore:Print("|cFFFF0000BLOCKED:|r You may not trade outside of duos/trios.")        
+		if level < max_level then
+        	Hardcore:Print("|cFFFF0000BLOCKED:|r You may not trade outside of duos/trios.")
+		else
+			table.insert(Hardcore_Character.trade_partners, target_trader)
+        	Hardcore_Character.trade_partners = Hardcore_FilterUnique(Hardcore_Character.trade_partners)
+		end
     end
 end)
 

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -916,6 +916,7 @@ TradeFrameTradeButton:SetScript("OnClick", function()
 		else
 			table.insert(Hardcore_Character.trade_partners, target_trader)
 			Hardcore_Character.trade_partners = Hardcore_FilterUnique(Hardcore_Character.trade_partners)
+			AcceptTrade()
 		end
 	end
 end)

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -896,8 +896,8 @@ TradeFrameTradeButton:SetScript("OnClick", function()
 	local level = UnitLevel("player")
 	local max_level = 60
 	if (Hardcore_Character.game_version ~= "") and
-	   (Hardcore_Character.game_version ~= "Era") and
-	   (Hardcore_Character.game_version ~= "SoM") then
+		(Hardcore_Character.game_version ~= "Era") and
+		(Hardcore_Character.game_version ~= "SoM") then
 		max_level = 80
 	end
 	if Hardcore_Character.team ~= nil then
@@ -909,15 +909,15 @@ TradeFrameTradeButton:SetScript("OnClick", function()
 		end
 	end
 	if duo_trio_partner == true then
-        AcceptTrade()        
-    else
+		AcceptTrade()
+	else
 		if level < max_level then
-        	Hardcore:Print("|cFFFF0000BLOCKED:|r You may not trade outside of duos/trios.")
+			Hardcore:Print("|cFFFF0000BLOCKED:|r You may not trade outside of duos/trios.")
 		else
 			table.insert(Hardcore_Character.trade_partners, target_trader)
-        	Hardcore_Character.trade_partners = Hardcore_FilterUnique(Hardcore_Character.trade_partners)
+			Hardcore_Character.trade_partners = Hardcore_FilterUnique(Hardcore_Character.trade_partners)
 		end
-    end
+	end
 end)
 
 --[[ Startup ]]

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -901,11 +901,11 @@ TradeFrameTradeButton:SetScript("OnClick", function()
 			end
 		end
 	end
-	if duo_trio_partner == false then
-		table.insert(Hardcore_Character.trade_partners, target_trader)
-		Hardcore_Character.trade_partners = Hardcore_FilterUnique(Hardcore_Character.trade_partners)
-	end
-	AcceptTrade()
+	if duo_trio_partner == true then
+        AcceptTrade()        
+    else
+        Hardcore:Print("|cFFFF0000BLOCKED:|r You may not trade outside of duos/trios.")        
+    end
 end)
 
 --[[ Startup ]]


### PR DESCRIPTION
This change prevents the Trade button from working if the trading partner isn't part of your duo/trio