### PR TITLE
Add exemption to Duo/Trio for max level characters

### DIFF
--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -184,6 +184,19 @@ function duo_rules:ResetWarn()
 end
 
 function duo_rules:Check()
+	-- this code causes the rules checker to ignore all duo/trio rules at max level
+	if _hardcore_character.game_version ~= nil then
+		local max_level
+		if _hardcore_character.game_version == "Era" or _hardcore_character.game_version == "SoM" then
+			max_level = 60
+		else -- if Hardcore_Character.game_version == "WotLK" or anything else
+			max_level = 80
+		end
+		if UnitLevel( "player" ) >= max_level then
+			return
+		end
+	end
+
 	local num_members = GetNumGroupMembers()
 	if num_members < 2 then
 		Hardcore:Print("Duo check: not in group")

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -185,9 +185,9 @@ end
 
 function duo_rules:Check()
 	-- this code causes the rules checker to ignore all duo/trio rules at max level
-	if _hardcore_character.game_version ~= nil then
+	if Hardcore_Character.game_version ~= nil then
 		local max_level
-		if _hardcore_character.game_version == "Era" or _hardcore_character.game_version == "SoM" then
+		if Hardcore_Character.game_version == "Era" or Hardcore_Character.game_version == "SoM" then
 			max_level = 60
 		else -- if Hardcore_Character.game_version == "WotLK" or anything else
 			max_level = 80

--- a/Achievements/Trio.lua
+++ b/Achievements/Trio.lua
@@ -231,6 +231,19 @@ function trio_rules:ResetWarn()
 end
 
 function trio_rules:Check()
+	-- this code causes the rules checker to ignore all duo/trio rules at max level
+	if _hardcore_character.game_version ~= nil then
+		local max_level
+		if _hardcore_character.game_version == "Era" or _hardcore_character.game_version == "SoM" then
+			max_level = 60
+		else -- if Hardcore_Character.game_version == "WotLK" or anything else
+			max_level = 80
+		end
+		if UnitLevel( "player" ) >= max_level then
+			return
+		end
+	end
+	
 	local num_members = GetNumGroupMembers()
 	if num_members < 3 then
 		Hardcore:Print("Trio check: not in big enough group")

--- a/Achievements/Trio.lua
+++ b/Achievements/Trio.lua
@@ -232,9 +232,9 @@ end
 
 function trio_rules:Check()
 	-- this code causes the rules checker to ignore all duo/trio rules at max level
-	if _hardcore_character.game_version ~= nil then
+	if Hardcore_Character.game_version ~= nil then
 		local max_level
-		if _hardcore_character.game_version == "Era" or _hardcore_character.game_version == "SoM" then
+		if Hardcore_Character.game_version == "Era" or Hardcore_Character.game_version == "SoM" then
 			max_level = 60
 		else -- if Hardcore_Character.game_version == "WotLK" or anything else
 			max_level = 80
@@ -243,7 +243,7 @@ function trio_rules:Check()
 			return
 		end
 	end
-	
+
 	local num_members = GetNumGroupMembers()
 	if num_members < 3 then
 		Hardcore:Print("Trio check: not in big enough group")


### PR DESCRIPTION
Added early returns to Duo.lua and Trio.lua for max_level characters.

The aim is to allow duos and trios to remain connected in the data, but without being impacted by connection requirements at max level.

This should provide room for all members of the group to reach maximum level, while also letting max level toons go and play as they wish.