### PR TITLE
Resolve errors in Trio range checking

### DIFF
--- a/Achievements/Trio.lua
+++ b/Achievements/Trio.lua
@@ -284,11 +284,12 @@ function trio_rules:Check()
 		return
 	end
 
-	local in_follow_range = CheckInteractDistance(member_str, 4)
-	if in_follow_range then
-		trio_rules:ResetWarn()
-		return
-	end
+	local in_follow_range_1 = CheckInteractDistance(member_str_1, 4)
+    	local in_follow_range_2 = CheckInteractDistance(member_str_2, 4)
+    	if in_follow_range_1 == true and in_follow_range_2 == true then
+        	trio_rules:ResetWarn()
+        	return
+    	end
 
 	local my_map = C_Map.GetBestMapForUnit("player")
 	local teammates_map_1 = C_Map.GetBestMapForUnit(member_str_1)


### PR DESCRIPTION
Appears the trio code was a dupe from duo, and didn't check the range of both partners for resetting the distance warning.