### PR TITLE
Handle nil kill_list_dict on quest turn in

### DIFF
--- a/Achievements/AchievementG.lua
+++ b/Achievements/AchievementG.lua
@@ -311,8 +311,10 @@ end
 
 function HCCommonPassiveAchievementKillCheck(_achievement, _event, _args)
 	if _event == "QUEST_TURNED_IN" then
-		if _args[1] == _achievement.quest_num and (UnitLevel("player") <= _achievement.level_cap or (hc_recent_level_up and UnitLevel("player") <= _achievement.level_cap + 1)) and Hardcore_Character.kill_list_dict[_achievement.kill_target] then
-			_achievement.succeed_function_executor.Succeed(_achievement.name)
+		if _args[1] == _achievement.quest_num and (UnitLevel("player") <= _achievement.level_cap or (hc_recent_level_up and UnitLevel("player") <= _achievement.level_cap + 1)) then
+			if Hardcore_Character.kill_list_dict ~= nil and Hardcore_Character.kill_list_dict[_achievement.kill_target] then
+				_achievement.succeed_function_executor.Succeed(_achievement.name)
+			end
 		end
 	end
 end

--- a/Achievements/AchievementG.lua
+++ b/Achievements/AchievementG.lua
@@ -314,6 +314,8 @@ function HCCommonPassiveAchievementKillCheck(_achievement, _event, _args)
 		if _args[1] == _achievement.quest_num and (UnitLevel("player") <= _achievement.level_cap or (hc_recent_level_up and UnitLevel("player") <= _achievement.level_cap + 1)) then
 			if Hardcore_Character.kill_list_dict ~= nil and Hardcore_Character.kill_list_dict[_achievement.kill_target] then
 				_achievement.succeed_function_executor.Succeed(_achievement.name)
+			else
+				Hardcore:Print("[" .. _achievement.title .. "] You have completed the " .. _achievement.quest_name .. " quest, but " .. _achievement.kill_target .. " was not slain!")
 			end
 		end
 	end


### PR DESCRIPTION
There are cases where the quest for a passive achieve can be completed without killing the kill_target. In this case, and when the character has never killed a kill_target, the kill_list_dict is nil. 

The fix here adds a nil check, treating it the same as if the kill target just was not in the dict. 

It also adds an else block, printing out an info message indicating that the kill target wasn't slain. I'm happy to take that part out if we don't want it.

![Screenshot 2023-01-25 155928](https://user-images.githubusercontent.com/121302503/214721230-24cb309b-aa72-4a40-9de6-89758af65421.png)

I believe this is what happened in the following 2 cases:
* Benny Blaanco not killed by the player: https://discord.com/channels/676996823537418262/1019682548143624303/1067609013866471504
* Rageclaw not killed by the player: https://discord.com/channels/676996823537418262/1019682548143624303/1067874573632147520
