### PR TITLE
Fix for EarthenArise

### DIFF
--- a/Achievements/EarthenArise.lua
+++ b/Achievements/EarthenArise.lua
@@ -33,5 +33,6 @@ end
 -- Register Definitions
 _achievement:SetScript("OnEvent", function(self, event, ...)
 	local arg = { ... }
+	-- Goggeroc is bugged, and does not award XP always, so is not required for awarding.
 	HCCommonPassiveAchievementBasicQuestCheck(_achievement, event, arg)
 end)

--- a/Achievements/EarthenArise.lua
+++ b/Achievements/EarthenArise.lua
@@ -33,5 +33,5 @@ end
 -- Register Definitions
 _achievement:SetScript("OnEvent", function(self, event, ...)
 	local arg = { ... }
-	HCCommonPassiveAchievementKillCheck(_achievement, event, arg)
+	HCCommonPassiveAchievementBasicQuestCheck(_achievement, event, arg)
 end)


### PR DESCRIPTION
Adjust EarthenArise to behave the same way that Counterattack behaves: the achievement is awarded if the quest is complete. The kill_target will be recorded separately, but is not treated as required for the Achievement. 

The EarthenArise passive achievement is not getting awarded. It appears that Goggeroc does not give any XP on kill. The discord link below has an example of it. This fix will allow the achieve to be awarded, but sill winds up not having a kill recorded for Goggeroc. I'm not sure what the implications of that are, since I'm not familiar with how the kill_list_dict is intended to be used (trophies?). 

I'm not sure if some of the PA kill checking is to prevent things like completing with assistance. Otherwise updating the kill_list_dict later (as a sort of "implied kill") would be another way to go. 

Example from discord:  
https://discord.com/channels/676996823537418262/1019682548143624303/1068359670676336680




