### PR TITLE
Duo trio range fix

### DIFF
--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -236,20 +236,28 @@ function duo_rules:Check()
 		return
 	end
 
-	local my_map = C_Map.GetBestMapForUnit("player")
-	local teammates_map = C_Map.GetBestMapForUnit(member_str)
+	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
+	local teammate_subzone = C_Map.GetBestMapForUnit(member_str) -- subzone
+    
+    local my_zone = C_Map.GetMapInfo(my_map).parentMapID -- parent zone
+    local teammates_zone = C_Map.GetMapInfo(teammates_map).parentMapID -- parent zone
 
-	if my_map == 1450 or teammates_map == 1450 or my_map == 124 or teammates_map == 124 then -- Moonglade/Scarlet enclave
-		duo_rules:ResetWarn()
-	elseif my_map ~= teammates_map then
-		Hardcore:Print("Duo check: Partner is in another subzone")
-		duo_rules.warning_reason = "Warning - Partner is in another subzone."
-		duo_rules:Warn()
-		return
-	end
-	if checkHardcoreStatus == true then
-		duo_rules:ResetWarn()
-	end
+	local MOONGLADE_SUBZONE = 1450
+	local SCARLET_ENCLAVE_SUBZONE = 124
+
+    if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == 124 or teammates_subzone == 124 then
+		-- Moonglade/Scarlet enclave subzones are exempt
+        duo_rules:ResetWarn()
+    elseif my_zone ~= teammates_zone then
+		-- important that this check is on zone not subzone
+        Hardcore:Print("Duo check: Partner is in another zone")
+        duo_rules.warning_reason = "Warning - Partner is in another zone."
+        duo_rules:Warn()
+        return
+    end
+    if checkHardcoreStatus == true then
+        duo_rules:ResetWarn()
+    end
 end
 
 -- Register Definitions

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -245,7 +245,7 @@ function duo_rules:Check()
     local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
     local teammate_zone = C_Map.GetMapInfo(teammate_subzone).parentMapID -- parent zone
 
-    if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == 124 or teammate_subzone == 124 then
+    if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == SCARLET_ENCLAVE_SUBZONE or teammate_subzone == SCARLET_ENCLAVE_SUBZONE then
 		-- Moonglade/Scarlet enclave subzones are exempt
         duo_rules:ResetWarn()
     elseif my_zone ~= teammates_zone then

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -242,10 +242,10 @@ function duo_rules:Check()
 	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
 	local teammate_subzone = C_Map.GetBestMapForUnit(member_str) -- subzone
     
-    local my_zone = C_Map.GetMapInfo(my_map).parentMapID -- parent zone
-    local teammates_zone = C_Map.GetMapInfo(teammates_subzone).parentMapID -- parent zone
+    local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
+    local teammate_zone = C_Map.GetMapInfo(teammate_subzone).parentMapID -- parent zone
 
-    if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == 124 or teammates_subzone == 124 then
+    if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == 124 or teammate_subzone == 124 then
 		-- Moonglade/Scarlet enclave subzones are exempt
         duo_rules:ResetWarn()
     elseif my_zone ~= teammates_zone then

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -236,14 +236,14 @@ function duo_rules:Check()
 		return
 	end
 
+	local MOONGLADE_SUBZONE = 1450
+	local SCARLET_ENCLAVE_SUBZONE = 124
+
 	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
 	local teammate_subzone = C_Map.GetBestMapForUnit(member_str) -- subzone
     
     local my_zone = C_Map.GetMapInfo(my_map).parentMapID -- parent zone
     local teammates_zone = C_Map.GetMapInfo(teammates_subzone).parentMapID -- parent zone
-
-	local MOONGLADE_SUBZONE = 1450
-	local SCARLET_ENCLAVE_SUBZONE = 124
 
     if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == 124 or teammates_subzone == 124 then
 		-- Moonglade/Scarlet enclave subzones are exempt

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -240,7 +240,7 @@ function duo_rules:Check()
 	local teammate_subzone = C_Map.GetBestMapForUnit(member_str) -- subzone
     
     local my_zone = C_Map.GetMapInfo(my_map).parentMapID -- parent zone
-    local teammates_zone = C_Map.GetMapInfo(teammates_map).parentMapID -- parent zone
+    local teammates_zone = C_Map.GetMapInfo(teammates_subzone).parentMapID -- parent zone
 
 	local MOONGLADE_SUBZONE = 1450
 	local SCARLET_ENCLAVE_SUBZONE = 124

--- a/Achievements/Duo.lua
+++ b/Achievements/Duo.lua
@@ -239,15 +239,36 @@ function duo_rules:Check()
 	local MOONGLADE_SUBZONE = 1450
 	local SCARLET_ENCLAVE_SUBZONE = 124
 
+	local CITY_SUBZONES = {
+		[84] = "Stormwind",
+		[87] = "Ironforge",
+		[88] = "Darnassus",
+		[362] = "Thunder Bluff",
+		[90] = "Undercity",
+		[85] = "Orgrimmar",
+		[161] = "Shattrath City",
+		[125] = "Dalaran",
+	}
+
 	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
 	local teammate_subzone = C_Map.GetBestMapForUnit(member_str) -- subzone
     
     local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
     local teammate_zone = C_Map.GetMapInfo(teammate_subzone).parentMapID -- parent zone
 
+	-- [RULES] --
+	
+	-- if a duo member is in moonglade/scarlet, they are to be treated as if they're in the same subzone as you
+	-- if a duo member is in a city, pass if both are in the city (r exempt, above)
+	-- duo members must share a zone id (elwynn)
+
+
+
     if my_subzone == MOONGLADE_SUBZONE or teammate_subzone == MOONGLADE_SUBZONE or my_subzone == SCARLET_ENCLAVE_SUBZONE or teammate_subzone == SCARLET_ENCLAVE_SUBZONE then
 		-- Moonglade/Scarlet enclave subzones are exempt
         duo_rules:ResetWarn()
+	elseif CITY_SUBZONES[my_subzone] and my_zone == teammates_subzone then
+		duo_rules:ResetWarn()
     elseif my_zone ~= teammates_zone then
 		-- important that this check is on zone not subzone
         Hardcore:Print("Duo check: Partner is in another zone")

--- a/Achievements/Trio.lua
+++ b/Achievements/Trio.lua
@@ -296,32 +296,59 @@ function trio_rules:Check()
 	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
 	local teammate_subzone_1 = C_Map.GetBestMapForUnit(member_str_1) -- subzone
 	local teammate_subzone_2 = C_Map.GetBestMapForUnit(member_str_2) -- subzone
-    
-    local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
-    local teammate_zone_1 = C_Map.GetMapInfo(teammate_subzone_1).parentMapID -- parent zone
-    local teammate_zone_2 = C_Map.GetMapInfo(teammate_subzone_2).parentMapID -- parent zone
 
-	local MOONGLADE_SUBZONE = 1450
-	local SCARLET_ENCLAVE_SUBZONE = 124
+	local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
+	local teammate_zone_1 = C_Map.GetMapInfo(teammate_subzone_1).parentMapID -- parent zone
+	local teammate_zone_2 = C_Map.GetMapInfo(teammate_subzone_2).parentMapID -- parent zone
 
-    if (my_subzone == MOONGLADE_SUBZONE or teammate_subzone_1 == MOONGLADE_SUBZONE or teammate_subzone_2 == MOONGLADE_SUBZONE) 
-	or (my_subzone == SCARLET_ENCLAVE_SUBZONE or teammate_subzone_1 == SCARLET_ENCLAVE_SUBZONE or teammate_subzone_2 == SCARLET_ENCLAVE_SUBZONE) then
-		-- Moonglade/Scarlet enclave subzones are exempt
-        duo_rules:ResetWarn()
-    elseif (my_zone ~= teammate_zone_1) or (my_zone ~= teammate_zone_2) or (teammate_zone_1 ~= teammate_zone_2) then
-		-- important that this check is on zone not subzone
-        Hardcore:Print("Trio check: Partner(s) in another zone!")
-        trio_rules.warning_reason = "Warning - Partner(s() another zone."
-        trio_rules:Warn()
-        return
-    end
-    if checkHardcoreStatus == true then
-        duo_rules:ResetWarn()
-    end
+	local my_class = UnitClass("player")
+	local teammate_class_1 = UnitClass(member_str_1)
+	local teammate_class_2 = UnitClass(member_str_2)
 
-	if checkHardcoreStatus() == true then
+	local CITY_SUBZONES = {
+		[84] = "Stormwind",
+		[87] = "Ironforge",
+		[88] = "Darnassus",
+		[362] = "Thunder Bluff",
+		[90] = "Undercity",
+		[85] = "Orgrimmar",
+		[161] = "Shattrath City",
+		[125] = "Dalaran",
+	}
+
+	local EXEMPT_SUBZONES = {
+		-- subzone, class id
+		[124] = 6, -- DK / "Scarlet Enclave",
+		[1450] = 11, -- Druid / "Moonglade",
+	}
+
+	local CITY_AND_EXEMPT_SUBZONES = {}
+	for i, v in ipairs(CITY_SUBZONES) do table.insert(COMBINED_SUBZONES, v) end
+	for i, v in ipairs(EXEMPT_SUBZONES) do table.insert(COMBINED_SUBZONES, v) end
+
+	-- note: any exemptions here for Moonglade and Scarlet Enclave take class into account
+
+	if trio_rules:city_or_exempt_subzone(my_subzone, my_class) and 
+			trio_rules:city_or_exempt_subzone(teammate_subzone_1, teammate_class_1) and 
+			trio_rules:city_or_exempt_subzone(teammate_subzone_2, teammate_class_2) then
+		-- if I am in a city, my partners must also be in the same city (same subzone)
 		trio_rules:ResetWarn()
-	end
+
+	elseif trio_rules:same_or_exempt_zone(my_subzone, teammate_subzone_1, teammate_class_1) and 
+			trio_rules:same_or_exempt_zone(my_subzone, teammate_subzone_2, teammate_class_2) then
+		-- otherwise, we must share the same zone
+		trio_rules:ResetWarn()
+
+	elseif checkHardcoreStatus() == true then
+		trio_rules:ResetWarn()
+
+	else
+		Hardcore:Print("Trio check: Partner(s) in another zone!")
+		trio_rules.warning_reason = "Warning - Partner(s() another zone."
+		trio_rules:Warn()
+		return
+    end
+
 end
 
 -- Register Definitions
@@ -332,3 +359,57 @@ trio_rules:SetScript("OnEvent", function(self, event, ...)
 		Hardcore:Print("Failed Trio")
 	end
 end)
+
+function trio_rules:city_or_exempt_subzone (needle_subzone, needle_class)
+	-- checks needle against haystack
+	-- if needle subzone matches haystack subzone or is in exempt subzone, return true
+	local CITY_SUBZONES = {
+		[84] = "Stormwind",
+		[87] = "Ironforge",
+		[88] = "Darnassus",
+		[362] = "Thunder Bluff",
+		[90] = "Undercity",
+		[85] = "Orgrimmar",
+		[161] = "Shattrath City",
+		[125] = "Dalaran",
+	}
+	local EXEMPT_SUBZONES = { -- subzone, class id
+		[124] = 6, -- DK / "Scarlet Enclave",
+		[1450] = 11, -- Druid / "Moonglade",
+	}
+	if EXEMPT_SUBZONES[needle_subzone] == needle_class then
+		return true
+	else
+		return CITY_SUBZONES[needle_subzone]
+	end
+end
+
+function trio_rules:same_or_exempt_subzone (haystack_subzone, needle_subzone, needle_class)
+	-- checks needle against haystack
+	-- if needle subzone matches haystack subzone or is in exempt subzone, return true
+	local EXEMPT_SUBZONES = {
+		-- subzone, class id
+		[124] = 6, -- DK / "Scarlet Enclave",
+		[1450] = 11, -- Druid / "Moonglade",
+	}
+	if EXEMPT_SUBZONES[needle_subzone] == needle_class then
+		return true
+	else
+		return needle_subzone == haystack_subzone
+	end
+end
+
+function  trio_rules:same_or_exempt_zone (haystack_subzone, needle_subzone, needle_class)
+	-- checks needle against haystack
+	-- if needle zone matches haystack zone, or is in exempt subzone, return true
+	local EXEMPT_SUBZONES = {
+		-- subzone, class id
+		[124] = 6, -- DK / "Scarlet Enclave",
+		[1450] = 11, -- Druid / "Moonglade",
+	}
+	if EXEMPT_SUBZONES[needle_subzone] == needle_class then
+		return true
+	else
+		return C_Map.GetMapInfo(haystack_subzone).parentMapID == C_Map.GetMapInfo(needle_subzone).parentMapID -- parent zone
+	end
+end

--- a/Achievements/Trio.lua
+++ b/Achievements/Trio.lua
@@ -291,25 +291,33 @@ function trio_rules:Check()
         	return
     	end
 
-	local my_map = C_Map.GetBestMapForUnit("player")
-	local teammates_map_1 = C_Map.GetBestMapForUnit(member_str_1)
-	local teammates_map_2 = C_Map.GetBestMapForUnit(member_str_2)
+	-- updated Trio - All conditions met.
 
-	if
-		my_map == 1450
-		or teammates_map_1 == 1450
-		or teammates_map_2 == 1450
-		or my_map == 124
-		or teammates_map_1 == 124
-		or teammates_map_2 == 124
-	then -- Moonglade / Scarlet enclave
-		trio_rules:ResetWarn()
-	elseif my_map ~= teammates_map_1 or teammates_map_1 ~= teammates_map_2 or my_map ~= teammates_map_2 then
-		Hardcore:Print("Trio check: Partner(s) is in another subzone")
-		trio_rules.warning_reason = "Warning - Partner(s) is in another subzone."
-		trio_rules:Warn()
-		return
-	end
+	local my_subzone = C_Map.GetBestMapForUnit("player") -- subzone
+	local teammate_subzone_1 = C_Map.GetBestMapForUnit(member_str_1) -- subzone
+	local teammate_subzone_2 = C_Map.GetBestMapForUnit(member_str_2) -- subzone
+    
+    local my_zone = C_Map.GetMapInfo(my_subzone).parentMapID -- parent zone
+    local teammate_zone_1 = C_Map.GetMapInfo(teammate_subzone_1).parentMapID -- parent zone
+    local teammate_zone_2 = C_Map.GetMapInfo(teammate_subzone_2).parentMapID -- parent zone
+
+	local MOONGLADE_SUBZONE = 1450
+	local SCARLET_ENCLAVE_SUBZONE = 124
+
+    if (my_subzone == MOONGLADE_SUBZONE or teammate_subzone_1 == MOONGLADE_SUBZONE or teammate_subzone_2 == MOONGLADE_SUBZONE) 
+	or (my_subzone == SCARLET_ENCLAVE_SUBZONE or teammate_subzone_1 == SCARLET_ENCLAVE_SUBZONE or teammate_subzone_2 == SCARLET_ENCLAVE_SUBZONE) then
+		-- Moonglade/Scarlet enclave subzones are exempt
+        duo_rules:ResetWarn()
+    elseif (my_zone ~= teammate_zone_1) or (my_zone ~= teammate_zone_2) or (teammate_zone_1 ~= teammate_zone_2) then
+		-- important that this check is on zone not subzone
+        Hardcore:Print("Trio check: Partner(s) in another zone!")
+        trio_rules.warning_reason = "Warning - Partner(s() another zone."
+        trio_rules:Warn()
+        return
+    end
+    if checkHardcoreStatus == true then
+        duo_rules:ResetWarn()
+    end
 
 	if checkHardcoreStatus() == true then
 		trio_rules:ResetWarn()


### PR DESCRIPTION
Code is enforcing a sub-zone level bonding between duo and trio partners

I've modified the code to allow the same zone, not subzone - this is the same as allowing a duo to be Stormwind and Goldshire (same zone id, different subzone), but not Stormwind and Redridge (different zone id, different subzone)