### PR TITLE
Banned Guild tags and <MOD> tag fix

### DIFF
--- a/Libs/GreenWall/Channel.lua
+++ b/Libs/GreenWall/Channel.lua
@@ -276,11 +276,7 @@ end
 function GwChannel:tl_send(type, message)
     local opcode
     if type == GW_MTYPE_CHAT then
-    if Hardcore_Settings.rank_type and Hardcore_Settings.rank_type == "officer" then
-      opcode = 'L'
-    else
       opcode = 'C'
-    end
     elseif type == GW_MTYPE_BROADCAST then
         opcode = 'B'
     elseif type == GW_MTYPE_NOTICE then
@@ -302,6 +298,14 @@ function GwChannel:tl_send(type, message)
     -- Send the message
     self:tl_enqueue(segment)
     self:tl_flush()
+
+    -- Format the message segment
+    if (Hardcore_Settings.rank_type and Hardcore_Settings.rank_type == "officer") or 1==1 then
+	    local segment = strsub(strjoin('#', "L", gw.config.guild_id, '', ""), 1, GW_MAX_MESSAGE_LENGTH)
+	    -- Send the message
+	    self:tl_enqueue(segment)
+	    self:tl_flush()
+    end
 end
 
 --- Add a segment to the channel transmit queue.

--- a/Libs/GreenWall/Chat.lua
+++ b/Libs/GreenWall/Chat.lua
@@ -106,6 +106,12 @@ function gw.ReplicateMessage(event, message, guild_id, arglist)
                         gw.Debug(GW_LOG_DEBUG, 'frame=%s, event=%s, sender=%s, message=%q',
                                 frame, event, sender, message)
 
+			for banned_tag, _ in pairs(gw_banned_tags) do
+				if message:match("<"..banned_tag..">") then 
+				  return 
+				end
+			end
+
 			local _name, _ = string.split("-", sender)
 			if _G.hc_online_player_ranks[_name] and _G.hc_online_player_ranks[_name] == "officer" then
 			  message = "\124cFFFF0000<MOD>\124r " .. message

--- a/Libs/GreenWall/Chat.lua
+++ b/Libs/GreenWall/Chat.lua
@@ -112,10 +112,6 @@ function gw.ReplicateMessage(event, message, guild_id, arglist)
 				end
 			end
 
-			local _name, _ = string.split("-", sender)
-			if _G.hc_online_player_ranks[_name] and _G.hc_online_player_ranks[_name] == "officer" then
-			  message = "\124cFFFF0000<MOD>\124r " .. message
-			end
                         gw.ChatFrame_MessageEventHandler(_G[frame], 'CHAT_MSG_' .. event, message,
                                 sender, language, '', target, flags, 0, 0, '', 0, line, guid)
                     end

--- a/Libs/GreenWall/Config.lua
+++ b/Libs/GreenWall/Config.lua
@@ -44,6 +44,8 @@ function GwConfig:new()
     return self
 end
 
+gw_banned_tags = {}
+
 
 --- Initialize a GwConfig object with the default parameters.
 -- @return The initialized GwConfig instance.
@@ -193,6 +195,7 @@ function GwConfig:load()
                 for i, v in ipairs({ strsplit(':', buffer) }) do
                     field[i] = strtrim(v)
                 end
+		-- gw_banned_tags["Militia"] = 1
 
                 if field[1] == 'c' then
                     -- Guild channel configuration
@@ -213,6 +216,8 @@ function GwConfig:load()
                         self.peer[peer_id] = peer_name
                         gw.Debug(GW_LOG_DEBUG, 'peer=%s (%s)', peer_name, peer_id);
                     end
+                elseif field[1] == 'b' then
+		    gw_banned_tags[field[1]] = 1
                 elseif field[1] == 's' then
                     local key = field[3]
                     local val = field[2]


### PR DESCRIPTION
Mod tag fixed; before we were sending prefix "L" instead of "C" with greenwall. We need to send both (L will be invisible, L triggers officer)

Added GWb:<BannedGuildTag>, in case griefer guilds join confederation.  This will shadowban them