### PR TITLE
Issue223 automate the release process

### DIFF
--- a/Release/prepareforupload.sh
+++ b/Release/prepareforupload.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Developed for Hardcore WoW by STM3256
+# Requirements: You need 7zip installed. It is free here: https://www.7-zip.org/
+# Run this at the root of the project in master branch
+# Enter the inputs when running this. 
+# Use -v to specify the version of the hardcore addon
+# Example useage in terminal while sitting at root of project:$ Release/prepareforupload.sh -v 0.11.7
+while getopts v:a:f: flag
+do
+    case "${flag}" in
+        v) hardcore_version=${OPTARG};;
+    esac
+done
+
+if [ -z $hardcore_version ]
+then
+	echo "Hardcore Version required for script. Use [-v <ARGUMENT>]";
+	exit 1
+else
+	echo "Hardcore Version: $hardcore_version";
+fi
+
+if [ -f "Hardcore.zip" ]
+then
+	echo "Hardcore zip already exists";
+	exit 1
+else
+	echo "Hardcore Version: $hardcore_version";
+fi
+
+CURRENT_MILLIS="$(($(date +%s%N)/1000000))"
+TEMPFOLDERNAME="temprelease_$hardcore_version-$CURRENT_MILLIS"
+RELEASEFOLDERNAME="releasehardcore_$hardcore_version-$CURRENT_MILLIS"
+echo $TEMPFOLDERNAME
+mkdir "../$TEMPFOLDERNAME"
+mkdir "../$RELEASEFOLDERNAME"
+cp -r . "../$TEMPFOLDERNAME"
+rm -rf .git
+rm -rf .vscode
+rm .gitignore
+rm -rf Release
+7z a ../$RELEASEFOLDERNAME/Hardcore.zip "../$TEMPFOLDERNAME"

--- a/Release/prepareforupload.sh
+++ b/Release/prepareforupload.sh
@@ -1,42 +1,53 @@
 #!/bin/sh
-# Developed for Hardcore WoW by STM3256
+# Developed for Hardcore WoW by STM3256 aka cheappurplesuit#9458
 # Requirements: You need 7zip installed. It is free here: https://www.7-zip.org/
-# Run this at the root of the project in master branch
-# Enter the inputs when running this. 
+# Run this at the root of the project in the branch of code you want to release
+# Expected output: A folder one level up from where it is run that contains a single zip named "Hardcore.zip" which when extracted has one folder named "Hardcore"
+# Enter the input flag when running this. 
 # Use -v to specify the version of the hardcore addon
 # Example useage in terminal while sitting at root of project:$ Release/prepareforupload.sh -v 0.11.7
-while getopts v:a:f: flag
+# After uploading the artifact, any folders beginning with "releasehardcore_" can safely be deleted
+while getopts v: flag
 do
     case "${flag}" in
         v) hardcore_version=${OPTARG};;
     esac
 done
 
+# Ensure a version is entered
 if [ -z $hardcore_version ]
 then
 	echo "Hardcore Version required for script. Use [-v <ARGUMENT>]";
+	echo "Example Use: $ Release/prepareforupload.sh -v 0.11.7 ";
 	exit 1
 else
 	echo "Hardcore Version: $hardcore_version";
 fi
 
-if [ -f "Hardcore.zip" ]
+# Check we are running at the root of the project
+if [ -f "Hardcore.toc" ]
 then
-	echo "Hardcore zip already exists";
-	exit 1
+	echo "Release script is running at the root of project, continuing..."
 else
-	echo "Hardcore Version: $hardcore_version";
+	echo "Release script is not running at the root of the project"
+	echo "Change directories to where you cloned it"
+	echo "Execute it like this in terminal that can run shell: $ Release/prepareforupload.sh -v 0.11.7"
+	exit 1
 fi
 
-CURRENT_MILLIS="$(($(date +%s%N)/1000000))"
-TEMPFOLDERNAME="temprelease_$hardcore_version-$CURRENT_MILLIS"
-RELEASEFOLDERNAME="releasehardcore_$hardcore_version-$CURRENT_MILLIS"
-echo $TEMPFOLDERNAME
+DATETIME="$(date +%F_%H-%M-%S)"
+TEMPFOLDERNAME="temprelease_$hardcore_version-$DATETIME"
+ZIPFOLDERNAME="Hardcore"
+FILENAME="Hardcore.zip"
+RELEASEFOLDERNAME="releasehardcore_$hardcore_version-$DATETIME"
 mkdir "../$TEMPFOLDERNAME"
+mkdir "../$TEMPFOLDERNAME/$ZIPFOLDERNAME"
 mkdir "../$RELEASEFOLDERNAME"
-cp -r . "../$TEMPFOLDERNAME"
-rm -rf .git
-rm -rf .vscode
-rm .gitignore
-rm -rf Release
-7z a ../$RELEASEFOLDERNAME/Hardcore.zip "../$TEMPFOLDERNAME"
+cp -r . "../$TEMPFOLDERNAME/$ZIPFOLDERNAME"
+rm -rf "../$TEMPFOLDERNAME/$ZIPFOLDERNAME/.git"
+rm -rf "../$TEMPFOLDERNAME/$ZIPFOLDERNAME/.vscode"
+rm -rf "../$TEMPFOLDERNAME/$ZIPFOLDERNAME/Release"
+rm "../$TEMPFOLDERNAME/$ZIPFOLDERNAME/.gitignore"
+7z a ../$RELEASEFOLDERNAME/$FILENAME "../$TEMPFOLDERNAME/$ZIPFOLDERNAME"
+rm -rf "../$TEMPFOLDERNAME"
+echo "Release $FILENAME created one level up in here: $RELEASEFOLDERNAME"


### PR DESCRIPTION
This script will do the following:
* Create Zip file for curseforge in a temp folder one level up
* removing non-dev files from the zip file (curseforge yells at you)
* Has guardrails in place and examples/explanation
* Instructions purposely omitted from Readme as this should really only be used by those with permissions to upload to curseforge
* Hardcore Version isn't strictly necessary for zip creation, but will be useful if we use curseforge API to upload artifacts. I can remove if requested.
 
Developers using this must have 7zip installed locally and can run shell scripts.
Script will need permissions to copy/create/delete files
