### PR TITLE
fixes 304 issue304, added warning for missing diplomat

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -1262,9 +1262,23 @@ local function GiveVidereWarning()
 	)
 end
 
+local function GiveQuestPvpWarning(text_to_display)
+	Hardcore:Print("|cFFFF0000WARNING:|r PVP Flag Warning!")
+	Hardcore:ShowAlertFrame(
+		ALERT_STYLES.videre_warning,
+		"WARNING: You will be PVP flagged when "  .. text_to_display
+	)
+end
+
 function Hardcore:QUEST_ACCEPTED(_, questID)
 	if questID == 3912 then
 		GiveVidereWarning()
+	end
+	if questID == 7843 then --The Final Message to the Wildhammer
+		GiveQuestPvpWarning("the spear is placed. PvP deaths are not appealable.")
+	end
+	if questID == 1266 then --The Missing Diplomat (quest before flag quest 1324)
+		GiveQuestPvpWarning("the next quest in the chain is accepted from Private Hendel. PvP deaths are not appealable.")
 	end
 end
 


### PR DESCRIPTION
 and final message to wildhammer quests that will pvp flag you.
 Purposely omitted the a rogue's deal quest because that is level 5 quest. If you die then, just restart.
 
 fixes #304 
 
 To test I added this code into the quest_Accepted function
 `
if questID == 376 then --Testing
`
`
		GiveQuestPvpWarning("you kill the bats")
`
`
	end
`
	
And the result was in the screenshot after I accepted the quest. 
screenshot: https://i.imgur.com/hrrYnjD.png