### PR TITLE
Add line on HC contract to cover multiple PC play

### DIFF
--- a/FirstMenuScreen.lua
+++ b/FirstMenuScreen.lua
@@ -86,6 +86,7 @@ function ShowFirstMenu(_hardcore_character, _hardcore_settings, _failure_functio
 			"+ \"I understand that buffing a PvP-flagged player will cause me to become PvP-flagged, and I may die,\"\n\n" .. 
 			"+ \"I understand that my presence in official guilds is subject to the Discord and Guild Rules (#getting-started, Discord)\"\n\n" ..  
 			"+ \"I understand that non-Classic HC affiliated guilds do not follow our standards, and thus are at your own risk.\"\n\n" .. 
+			"+ \"I understand that playing on multiple computers requires copying files as described in the FAQ (#faq, Discord).\"\n\n" .. 
 			""
 		)
 		second_menu_description:SetFont("Fonts\\FRIZQT__.TTF", 12, "")


### PR DESCRIPTION
Due to player request, we've added another clause to the "Hardcore Contract", mentioning the need to copy files to play on multiple computers and where to find that information.