### PR TITLE
Nudist Achievement Failure Checks Revamp

### DIFF
--- a/Achievements/Nudist.lua
+++ b/Achievements/Nudist.lua
@@ -37,21 +37,21 @@ nudist_achievement:SetScript("OnEvent", function(self, event, ...)
 			-- Equipped an item if true
 			if arg[2] ~= true then
 				-- Timed for accidental equips
-				TimedNudistFailure()
+				nudist_achievement:TimedNudistFailure()
 			end
 		end
 	elseif event == "PLAYER_LEVEL_UP" or event == "PLAYER_ENTER_COMBAT" or event == "UNIT_SPELLCAST_SUCCEEDED" then
 		-- Instant when it can affect actual gameplay
-		CheckNudistFailure()
+		nudist_achievement:CheckNudistFailure()
 	elseif event == "PLAYER_ENTERING_WORLD" then
-		if HasEquipment() then
+		if nudist_achievement:HasEquipment() then
 			-- Timed when entering the world, delay so they can hear the sound
-			C_Timer.After(0, function() TimedNudistFailure() end)
+			C_Timer.After(0, function() nudist_achievement:TimedNudistFailure() end)
 		end
 	end
 end)
 
-function HasEquipment()
+function nudist_achievement:HasEquipment()
 	for i = 2, 15 do
 		if GetInventoryItemID("player", i) then
 			return true
@@ -59,15 +59,15 @@ function HasEquipment()
 	end
 end
 
-function CheckNudistFailure()
-	if HasEquipment() then
+function nudist_achievement:CheckNudistFailure()
+	if nudist_achievement:HasEquipment() then
 		nudist_achievement.fail_function_executor.Fail(nudist_achievement.name)
 	end
 end
 
-function TimedNudistFailure()
+function nudist_achievement:TimedNudistFailure()
 	-- Check after 10 seconds if they still have items equipped
-	C_Timer.After(10, function() CheckNudistFailure() end)
+	C_Timer.After(10, function() nudist_achievement:CheckNudistFailure() end)
 	Hardcore:Print("NUDIST: Equipped an item\nUnequip within 10 seconds or you will fail the Achievement")
 	Hardcore:ShowAlertFrame(Hardcore.ALERT_STYLES.hc_red, "NUDIST: Equipped an item\nUnequip within 10 seconds or you will fail the Achievement")
 end

--- a/Achievements/Nudist.lua
+++ b/Achievements/Nudist.lua
@@ -15,12 +15,16 @@ nudist_achievement.description =
 function nudist_achievement:Register(fail_function_executor)
 	nudist_achievement:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	nudist_achievement:RegisterEvent("PLAYER_LEVEL_UP")
+	nudist_achievement:RegisterEvent("PLAYER_ENTER_COMBAT")
+	nudist_achievement:RegisterEvent("PLAYER_ENTERING_WORLD")
 	nudist_achievement.fail_function_executor = fail_function_executor
 end
 
 function nudist_achievement:Unregister()
 	nudist_achievement:UnregisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	nudist_achievement:UnregisterEvent("PLAYER_LEVEL_UP")
+	nudist_achievement:UnregisterEvent("PLAYER_ENTER_COMBAT")
+	nudist_achievement:UnregisterEvent("PLAYER_ENTERING_WORLD")
 end
 
 -- Register Definitions
@@ -28,15 +32,40 @@ nudist_achievement:SetScript("OnEvent", function(self, event, ...)
 	local arg = { ... }
 	if event == "PLAYER_EQUIPMENT_CHANGED" then
 		if arg[1] > 1 and arg[1] < 16 then -- 1 ammo, 16+ weapons
+			-- Equipped an item if true
 			if arg[2] ~= true then
-				nudist_achievement.fail_function_executor.Fail(nudist_achievement.name)
+				-- Timed for accidental equips
+				TimedNudistFailure()
 			end
 		end
-	elseif event == "PLAYER_LEVEL_UP" then
-		for i = 2, 15 do
-			if GetInventoryItemID("player", i) then
-				nudist_achievement.fail_function_executor.Fail(nudist_achievement.name)
-			end
+	elseif event == "PLAYER_LEVEL_UP" or event == "PLAYER_ENTER_COMBAT" then
+		-- Instant when it can affect actual gameplay
+		CheckNudistFailure()
+	elseif event == "PLAYER_ENTERING_WORLD" then
+		if HasEquipment() then
+			-- Timed when entering the world, delay so they can hear the sound
+			C_Timer.After(0, function() TimedNudistFailure() end)
 		end
 	end
 end)
+
+function HasEquipment()
+	for i = 2, 15 do
+		if GetInventoryItemID("player", i) then
+			return true
+		end
+	end
+end
+
+function CheckNudistFailure()
+	if HasEquipment() then
+		nudist_achievement.fail_function_executor.Fail(nudist_achievement.name)
+	end
+end
+
+function TimedNudistFailure()
+	-- Check after 10 seconds if they still have items equipped
+	C_Timer.After(10, function() CheckNudistFailure() end)
+	Hardcore:Print("NUDIST: Equipped an item\nUnequip within 10 seconds or you will fail the Achievement")
+	Hardcore:ShowAlertFrame(Hardcore.ALERT_STYLES.hc_red, "NUDIST: Equipped an item\nUnequip within 10 seconds or you will fail the Achievement")
+end

--- a/Achievements/Nudist.lua
+++ b/Achievements/Nudist.lua
@@ -17,6 +17,7 @@ function nudist_achievement:Register(fail_function_executor)
 	nudist_achievement:RegisterEvent("PLAYER_LEVEL_UP")
 	nudist_achievement:RegisterEvent("PLAYER_ENTER_COMBAT")
 	nudist_achievement:RegisterEvent("PLAYER_ENTERING_WORLD")
+	nudist_achievement:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 	nudist_achievement.fail_function_executor = fail_function_executor
 end
 
@@ -25,6 +26,7 @@ function nudist_achievement:Unregister()
 	nudist_achievement:UnregisterEvent("PLAYER_LEVEL_UP")
 	nudist_achievement:UnregisterEvent("PLAYER_ENTER_COMBAT")
 	nudist_achievement:UnregisterEvent("PLAYER_ENTERING_WORLD")
+	nudist_achievement:UnregisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 end
 
 -- Register Definitions
@@ -38,7 +40,7 @@ nudist_achievement:SetScript("OnEvent", function(self, event, ...)
 				TimedNudistFailure()
 			end
 		end
-	elseif event == "PLAYER_LEVEL_UP" or event == "PLAYER_ENTER_COMBAT" then
+	elseif event == "PLAYER_LEVEL_UP" or event == "PLAYER_ENTER_COMBAT" or event == "UNIT_SPELLCAST_SUCCEEDED" then
 		-- Instant when it can affect actual gameplay
 		CheckNudistFailure()
 	elseif event == "PLAYER_ENTERING_WORLD" then


### PR DESCRIPTION
Failing an achievement because you accidentally right click an item is not very fun, so I added a timer that starts when you equip an invalid item and checks if you still have the item equipped after 10 seconds. This timer restarts if you reload the game.

The game also immediately checks and fails you if you have items equipped when you enter combat since this would be a case where it actually affects gameplay. It also checks when you successfully cast a spell as a last resort to prevent people from using items like rocket boots or harm prevention belts by exiting the game repeatedly until they are usable.