### PR TITLE
DT improvement

### DIFF
--- a/Dungeons.lua
+++ b/Dungeons.lua
@@ -913,6 +913,11 @@ local function CombatLogEventHandler( self, event )
 	-- Get the combat log data
 	local time_stamp, subevent, _, src_guid, src_name, _, _, dst_guid, dst_name = CombatLogGetCurrentEventInfo()
 
+	-- We don't want to accidentally identify anything from previous runs (SM wings), like dots and debuffs timing out
+	if subevent == "SPELL_AURA_REMOVED" or subevent == "SPELL_AURA_REMOVED_DOSE" then
+		return
+	end
+
 	-- Combat events have a source and a destination (doing and getting the damage). We don't care which one is the NPC.
 	-- If it's an NPC, we'll take it.
 	local mob_guid = nil

--- a/Dungeons.lua
+++ b/Dungeons.lua
@@ -522,10 +522,18 @@ local function DungeonTrackerWarnInfraction()
 	for i, v in ipairs(Hardcore_Character.dt.runs) do
 		if DungeonTrackerIsRepeatedRun(v, Hardcore_Character.dt.current) then
 			Hardcore_Character.dt.current.last_warn = Hardcore_Character.dt.current.time_inside
-			message = "\124cffFF0000You entered "
+			local instance_info1 = ""
+			local instance_info2 = ""
+			if v.iid ~= nil and Hardcore_Character.dt.current.iid ~= nil and v.iid ~= Hardcore_Character.dt.current.iid then
+				instance_info1 = " (ID:" .. Hardcore_Character.dt.current.iid .. ")"
+				instance_info2 = " (ID:" .. v.iid .. ")"
+			end
+			message = "\124cffFF0000You entered " 
 				.. v.name
+				.. instance_info1
 				.. " already at date "
 				.. v.date
+				.. instance_info2
 				.. " -- leave the dungeon within "
 				.. time_left
 				.. " seconds!"
@@ -534,6 +542,8 @@ local function DungeonTrackerWarnInfraction()
 		end
 	end
 
+	-- The following code probably can't ever be called, since pending runs with different instance IDs are automatically
+	-- logged upon entry. But let's keep it here for now. Better warned twice, than never.
 	-- See if this dungeon was already in the list of pending runs (but with a different instanceID), and warn every so many seconds if that is so
 	for i, v in ipairs(Hardcore_Character.dt.pending) do
 		-- We never warn about pending runs without an instanceID, they may or may not be the same as the current
@@ -572,20 +582,18 @@ local function DungeonTrackerLogRun(run)
 	end
 
 	-- Warn if this is a repeated run and log
-	local v_iid
 	for i, v in ipairs(Hardcore_Character.dt.runs) do
 		if DungeonTrackerIsRepeatedRun(v, run) then
-			if v_iid ~= nil then
-				v_iid = v.iid
-			else
-				v_iid = 0
+			local instance_info = ""
+			if v.iid ~= nil then
+				instance_info = " (ID:" .. v.iid ..  ")"
 			end
 			if Hardcore_Character.dt.warn_infractions == true then
 				Hardcore:Print(
-					"\124cffFF0000Player entered "
-						.. run.name .. " (" .. run.iid .. ")"
+					"\124cffFF0000You entered "
+						.. run.name .. " (ID:" .. run.iid .. ")"
 						.. " already on "
-						.. v.date .. " (" .. v_iid .. ")"
+						.. v.date .. instance_info
 						.. " -- logging repeated run"
 				)
 			end
@@ -597,7 +605,7 @@ local function DungeonTrackerLogRun(run)
 	local max_level = DungeonTrackerGetDungeonMaxLevel(run.name)
 	if run.level > max_level then
 		if Hardcore_Character.dt.warn_infractions == true then
-			Hardcore:Print("\124cffFF0000Player was overleveled for " .. run.name .. " -- logging overleveled run")
+			Hardcore:Print("\124cffFF0000You were overleveled for " .. run.name .. " -- logging overleveled run")
 		end
 	end
 
@@ -1221,7 +1229,7 @@ local function DungeonTracker()
 			then
 				-- A pending run with the same dungeon name exists, but a different instance ID => log it immediately
 				Hardcore_Character.dt.pending[i].log_now = nil			-- clean up
-				Hardcore:Print("Forced logging of pending run in " .. Hardcore_Character.dt.pending[i].name .. " with different instance ID")
+				Hardcore:Debug("Forced logging of pending run in " .. Hardcore_Character.dt.pending[i].name .. " with different instance ID")
 				DungeonTrackerLogRun(Hardcore_Character.dt.pending[i])
 				table.remove(Hardcore_Character.dt.pending, i)
 			else

--- a/MainMenu.lua
+++ b/MainMenu.lua
@@ -1304,12 +1304,19 @@ local function DrawDungeonsTab(container, _hardcore_character)
 			end
 		end
 
+		local function GetInstanceIDString(run)
+			if run.iid ~= nil then
+				return " [" .. run.iid .. "]"
+			end
+			return ""
+		end
+
 		local now = GetServerTime()
 
 		-- Go through the complete, idle and active runs
 		local num_lines = 0
 		for i, v in pairs(_dt_runs) do
-			name_str = name_str .. v.name .. "\n"
+			name_str = name_str .. v.name .. GetInstanceIDString(v) .. "\n"
 			if v.level > 0 then
 				level_str = level_str .. v.level .. "\n"
 			else
@@ -1325,7 +1332,7 @@ local function DrawDungeonsTab(container, _hardcore_character)
 			num_lines = num_lines + 1
 		end
 		for i, v in pairs(_dt_pending) do
-			name_str = name_str .. "|c00FFFF00" .. v.name .. " (idle, " .. SecondsToTime(v.idle) .. ")\n"
+			name_str = name_str .. "|c00FFFF00" .. v.name .. GetInstanceIDString(v) .. " (idle, " .. SecondsToTime(v.idle) .. ")\n"
 			level_str = level_str .. v.level .. "\n"
 			played_str = played_str .. SecondsToTime(v.time_inside) .. "\n"
 			date_str = date_str .. v.date .. "\n"
@@ -1333,7 +1340,7 @@ local function DrawDungeonsTab(container, _hardcore_character)
 			num_lines = num_lines + 1
 		end
 		if next(_dt_current) then
-			name_str = name_str .. "|c0000FF00" .. _dt_current.name .. " (active)\n"
+			name_str = name_str .. "|c0000FF00" .. _dt_current.name .. GetInstanceIDString(_dt_current) .. " (active)\n"
 			level_str = level_str .. _dt_current.level .. "\n"
 			played_str = played_str .. SecondsToTime(_dt_current.time_inside) .. "\n"
 			date_str = date_str .. _dt_current.date .. "\n"


### PR DESCRIPTION
- Fixed bug where pending debuffs would mess with SM wing identification
- Added showing of instance IDs in warnings and dungeon tab
- Immediate logging of pending runs (or dropping for short runs) with different instance IDs to prevent spurious messages
