### PR TITLE
Fixes Ephemeral Failing Incorrectly

### DIFF
--- a/Achievements/Ephemeral.lua
+++ b/Achievements/Ephemeral.lua
@@ -16,11 +16,11 @@ ephemeral_achievement.description =
 function ephemeral_achievement:Register(fail_function_executor)
 	ephemeral_achievement:RegisterEvent("MERCHANT_SHOW")
 	MerchantRepairAllButton:SetScript("OnClick", function()
-		ephemeral_achievement.fail_function_executor.Fail(ephemeral_achievement.name)
+		--ephemeral_achievement.fail_function_executor.Fail(ephemeral_achievement.name)
 	end)
 
 	MerchantRepairItemButton:SetScript("OnClick", function()
-		ephemeral_achievement.fail_function_executor.Fail(ephemeral_achievement.name)
+		--ephemeral_achievement.fail_function_executor.Fail(ephemeral_achievement.name)
 	end)
 
 	ephemeral_achievement.fail_function_executor = fail_function_executor


### PR DESCRIPTION
There is currently an issue where the repair button for Ephemeral still shows, people mistakenly click this I assume by sheer habit, but it doesn't repair your items even if you do click it since overriding the onclick function like the achievement does removes all normal click functions anyways, so there's really no reason it should fail.

/script ActionButton1:SetScript("OnClick", function() print("Test") end)

This script does the same for actionbuttons, if you click on something in action button 1 after running this it won't do the normal ability it will simply print Test.

There are other ways that people can get past the achievement restrictions that I don't really know how to handle at the moment without just outright tracking all item durabilities so I think this is really the best temporary solution since it currently only punishes normal people who can't repair either way.