### PR TITLE
Support asian clients for death alerts, death logs and levels

### DIFF
--- a/DeathLog.lua
+++ b/DeathLog.lua
@@ -101,6 +101,19 @@ death_tomb_frame_tex_glow:SetHeight(55)
 death_tomb_frame_tex_glow:SetWidth(55)
 death_tomb_frame_tex_glow:Hide()
 
+local death_log_frame_font = "Fonts\\FRIZQT__.TTF"
+local locale = GetLocale()
+local non_english_locales = {
+  koKR=1,
+  zhCN=1,
+  zhTW=1
+}
+
+if non_english_locales[locale] == 1 then
+  death_log_frame_font = "Fonts\\2002.TTF"
+end
+
+
 local function encodeMessage(name, guild, source_id, race_id, class_id, level, instance_id, map_id, map_pos)
   if name == nil then return end
   -- if guild == nil then return end -- TODO 
@@ -268,7 +281,7 @@ for i=1,20 do
 	    _entry.font_strings[v[1]]:SetWidth(v[2])
 	  end
 	  _entry.font_strings[v[1]]:SetTextColor(1,1,1)
-	  _entry.font_strings[v[1]]:SetFont("Fonts\\FRIZQT__.TTF", 11, "")
+	  _entry.font_strings[v[1]]:SetFont(death_log_frame_font, 11, "")
 	end
 
 	_entry.background = _entry.frame:CreateTexture(nil, "OVERLAY")
@@ -280,7 +293,7 @@ for i=1,20 do
 	_entry.background:SetTexture("Interface\\ChatFrame\\ChatFrameBackground")
 
 	_entry:SetHeight(40)
-	_entry:SetFont("Fonts\\FRIZQT__.TTF", 16, "")
+	_entry:SetFont(death_log_frame_font, 16, "")
 	_entry:SetColor(1,1,1)
 	_entry:SetText(" ")
 

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -308,6 +308,21 @@ local display = "Rules"
 local displaylist = Hardcore_Settings.level_list
 local icon = nil
 
+
+local locale = GetLocale()
+hardcore_locale_supported_font = nil
+local non_english_locales = {
+  koKR=1,
+  zhCN=1,
+  zhTW=1
+}
+
+if non_english_locales[locale] == 1 then
+	hardcore_locale_supported_font = "Fonts\\2002.TTF"
+	_G["HardcoreFont"]:SetFont(hardcore_locale_supported_font,26, "")
+end
+
+
 -- available alert frame/icon styles
 local MEDIA_DIR = "Interface\\AddOns\\Hardcore\\Media\\"
 local ALERT_STYLES = {

--- a/MainMenu.lua
+++ b/MainMenu.lua
@@ -844,7 +844,7 @@ local function DrawLevelsTab(container, _hardcore_settings)
 		local name_label = AceGUI:Create("Label")
 		name_label:SetWidth(width)
 		name_label:SetText(name_str)
-		name_label:SetFont("Fonts\\FRIZQT__.TTF", 12, "")
+		name_label:SetFont(hardcore_locale_supported_font or "Fonts\\FRIZQT__.TTF", 12, "")
 		entry:AddChild(name_label)
 	end
 
@@ -865,7 +865,7 @@ local function DrawLevelsTab(container, _hardcore_settings)
 		local name_label = AceGUI:Create("Label")
 		name_label:SetWidth(width)
 		name_label:SetText(name_str)
-		name_label:SetFont("Fonts\\FRIZQT__.TTF", 12, "")
+		name_label:SetFont(hardcore_locale_supported_font or "Fonts\\FRIZQT__.TTF", 12, "")
 		entry:AddChild(name_label)
 	end
 
@@ -890,7 +890,7 @@ local function DrawLevelsTab(container, _hardcore_settings)
 		local name_label = AceGUI:Create("Label")
 		name_label:SetWidth(width)
 		name_label:SetText(name_str)
-		name_label:SetFont("Fonts\\FRIZQT__.TTF", 12, "")
+		name_label:SetFont(hardcore_locale_supported_font or "Fonts\\FRIZQT__.TTF", 12, "")
 		entry:AddChild(name_label)
 	end
 
@@ -911,7 +911,7 @@ local function DrawLevelsTab(container, _hardcore_settings)
 		local name_label = AceGUI:Create("Label")
 		name_label:SetWidth(width)
 		name_label:SetText(name_str)
-		name_label:SetFont("Fonts\\FRIZQT__.TTF", 12, "")
+		name_label:SetFont(hardcore_locale_supported_font or "Fonts\\FRIZQT__.TTF", 12, "")
 		entry:AddChild(name_label)
 	end
 


### PR DESCRIPTION
Not the cleanest approach, but covers the main use cases.




![image](https://github.com/Zarant/WoW_Hardcore/assets/1103800/1bcf8312-a24a-45a8-b898-7f3e155d2742)

![image](https://github.com/Zarant/WoW_Hardcore/assets/1103800/89f3c612-7904-4c3c-9f84-3abf27f25072)

![image](https://github.com/Zarant/WoW_Hardcore/assets/1103800/5c6a1944-bbba-48f3-9b4a-f3c3f2652775)



## What I tested
- English client (keeps old font)
- Korean client (changes font)

## How to test
![image](https://github.com/Zarant/WoW_Hardcore/assets/1103800/072f1473-9c7d-4581-913c-48e423213b41)
![image](https://github.com/Zarant/WoW_Hardcore/assets/1103800/1badc003-1c19-4985-b285-d32c85fbd3fe)
