### PR TITLE
Thunderstruck Translations

### DIFF
--- a/Achievements/Thunderstruck.lua
+++ b/Achievements/Thunderstruck.lua
@@ -59,18 +59,19 @@ local blacklist = {
 	["Arma Estigma de Escarcha"] = 1,
 
 	-- Same list, now in Italian
+	-- Unlike other languages, these translations come from Wowhead Retail instead of Wowhead Classic, therefore there is a (small) risk that translations are wrong
 	-- Forbidden fire spells
---	["Fire Nova Totem"] = 1,
---	["Flame Shock"] = 1,
---	["Flametongue Totem"] = 1,
---	["Flametongue Weapon"] = 1,
---	["Frost Resistance Totem"] = 1,
---	["Magma Totem"] = 1,
---	["Searing Totem"] = 1,
+	["Totem dell'Esplosione di Fuoco"] = 1,
+	["Folgore del Fuoco"] = 1,
+	["Totem della Lingua di Fuoco"] = 1,
+	["Arma della Lingua di Fuoco"] = 1,
+--	["Frost Resistance Totem"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
+	["Totem del Magma"] = 1,
+	["Totem delle Fiamme"] = 1,
 	-- Forbidden frost spells
---	["Fire Resistance Totem"] = 1,
---	["Frost Shock"] = 1,
---	["Frostbrand Weapon"] = 1,
+--	["Fire Resistance Totem"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
+	["Folgore del Gelo"] = 1,
+--	["Frostbrand Weapon"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
 
 	-- Same list, now in Portuguese
 	-- Forbidden fire spells

--- a/Achievements/Thunderstruck.lua
+++ b/Achievements/Thunderstruck.lua
@@ -50,19 +50,6 @@ local blacklist = {
 	["Choque de Escarcha"] = 1,
 	["Arma Estigma de Escarcha"] = 1,
 
-	-- Same list, now in Italian
-	-- Unlike other languages, these translations come from Wowhead Retail instead of Wowhead Classic, therefore there is a (small) risk that translations are wrong
-	-- Forbidden fire spells
-	["Totem dell'Esplosione di Fuoco"] = 1,
-	["Folgore del Fuoco"] = 1,
-	["Totem della Lingua di Fuoco"] = 1,
-	["Arma della Lingua di Fuoco"] = 1,
-	["Totem del Magma"] = 1,
-	["Totem delle Fiamme"] = 1,
-	-- Forbidden frost spells
-	["Folgore del Gelo"] = 1,
---	["Frostbrand Weapon"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
-
 	-- Same list, now in Portuguese
 	-- Forbidden fire spells
 	["Totem de Nova de Fogo"] = 1,

--- a/Achievements/Thunderstruck.lua
+++ b/Achievements/Thunderstruck.lua
@@ -58,6 +58,75 @@ local blacklist = {
 	["Choque de Escarcha"] = 1,
 	["Arma Estigma de Escarcha"] = 1,
 
+	-- Same list, now in Italian
+	-- Forbidden fire spells
+--	["Fire Nova Totem"] = 1,
+--	["Flame Shock"] = 1,
+--	["Flametongue Totem"] = 1,
+--	["Flametongue Weapon"] = 1,
+--	["Frost Resistance Totem"] = 1,
+--	["Magma Totem"] = 1,
+--	["Searing Totem"] = 1,
+	-- Forbidden frost spells
+--	["Fire Resistance Totem"] = 1,
+--	["Frost Shock"] = 1,
+--	["Frostbrand Weapon"] = 1,
+
+	-- Same list, now in Portuguese
+	-- Forbidden fire spells
+	["Totem de Nova de Fogo"] = 1,
+	["Choque Flamejante"] = 1,
+	["Totem de Labaredas"] = 1,
+	["Arma de Labaredas"] = 1,
+	["Totem de Resistência ao Gelo"] = 1,
+--	["Totem de Magma"] = 1, -- Same as French
+	["Totem Calcinante"] = 1,
+	-- Forbidden frost spells
+	["Totem de Resistência ao Fogo"] = 1,
+	["Choque Gélido"] = 1,
+	["Arma da Marca Gélida"] = 1,
+
+	-- Same list, now in Russian
+	-- Forbidden fire spells
+	["Тотем кольца огня"] = 1,
+	["Огненный шок"] = 1,
+	["Тотем языка пламени"] = 1,
+	["Оружие языка пламени"] = 1,
+	["Тотем сопротивления льду"] = 1,
+	["Тотем магмы"] = 1,
+	["Опаляющий тотем"] = 1,
+	-- Forbidden frost spells
+	["Тотем сопротивления огню"] = 1,
+	["Ледяной шок"] = 1,
+	["Оружие ледяного клейма"] = 1,
+
+	-- Same list, now in Korean
+	-- Forbidden fire spells
+	["불꽃 회오리 토템"] = 1,
+	["화염 충격"] = 1,
+	["불꽃의 토템"] = 1,
+	["불꽃의 무기"] = 1,
+	["냉기 저항 토템"] = 1,
+	["용암 토템"] = 1,
+	["불타는 토템"] = 1,
+	-- Forbidden frost spells
+	["화염 저항 토템"] = 1,
+	["냉기 충격"] = 1,
+	["냉기의 무기"] = 1,
+
+	-- Same list, now in Chinese
+	-- Forbidden fire spells
+	["火焰新星图腾"] = 1,
+	["烈焰震击"] = 1,
+	["火舌图腾"] = 1,
+	["火舌武器"] = 1,
+	["抗寒图腾"] = 1,
+	["熔岩图腾"] = 1,
+	["灼热图腾"] = 1,
+	-- Forbidden frost spells
+	["抗火图腾"] = 1,
+	["冰霜震击"] = 1,
+	["冰封武器"] = 1,
 }
 
 

--- a/Achievements/Thunderstruck.lua
+++ b/Achievements/Thunderstruck.lua
@@ -2,7 +2,19 @@ local _G = _G
 local thunderstruck_achievement = CreateFrame("Frame")
 _G.achievements.Thunderstruck = thunderstruck_achievement
 
+--[[
+	The list below can be obtained by entering the following lines in the chat, for each language.
+/run LocaleMap = { ["enUS"]="English", ["koKR"]="Korean", ["frFR"]="French", ["deDE"]="German", ["zhCN"]="Chinese (Simplified)", ["esES"]="Spanish", ["zhTW"]="Chinese (Traditional)", ["esMX"]="Spanish", ["ruRU"]="Russian", ["ptBR"]="Portuguese" }
+/run f=CreateFrame("Frame") f:SetPoint("TOPLEFT",200,-200) f:SetWidth(256) f:SetHeight(128) f.t=f:CreateTexture() f.t:SetColorTexture(0,0,0.5); f.t:SetAllPoints()
+/run CBT = function(b,icon) b[icon]=b:CreateTexture() b[icon]:SetTexture("Interface/Buttons/UI-Panel-MinimizeButton-"..icon) b[icon]:SetAllPoints() b[icon]:SetTexCoord(0.08,0.9,0.1,0.9) return b[icon] end
+/run b=CreateFrame("Button",nil,f) b:SetPoint("TOPRIGHT",0,0) b:SetWidth(14) b:SetHeight(14) b:SetScript("OnClick", function() f:Hide() end) b:SetNormalTexture(CBT(b,"Up")) b:SetPushedTexture(CBT(b,"Down")) b:SetHighlightTexture(CBT(b,"Highlight"))
+/run s="\t-- Spell names, in "..LocaleMap[GetLocale()].."\n" AddText = function(x) if type(x) == "string" then s=s.."\t-- Forbidden "..x.." spells\n" else n=GetSpellInfo(x) if n then s=s.."\t[\""..n.."\"] = 1,\n" end end end
+/run g=CreateFrame("EditBox", nil, f) g:SetMultiLine(true) g:SetAutoFocus(false) g:SetAllPoints() g:SetFontObject(GameTooltipTextSmall) for _,x in ipairs({"fire",1535,8050,8227,8024,8190,3599,2894,51505,"frost",8056,8033}) do AddText(x) end g:SetText(s)
+
+	It opens an edit box with preformatted code. Simply copy/paste the contents of the edit box to the source code below.
+]]
 local blacklist = {
+	-- Spell names, in English
 	-- Forbidden fire spells
 	["Fire Nova Totem"] = 1,
 	["Flame Shock"] = 1,
@@ -14,7 +26,7 @@ local blacklist = {
 	["Frost Shock"] = 1,
 	["Frostbrand Weapon"] = 1,
 
-	-- Same list, now in French
+	-- Spell names, in French
 	-- Forbidden fire spells
 	["Totem Nova de feu"] = 1,
 	["Horion de flammes"] = 1,
@@ -26,7 +38,7 @@ local blacklist = {
 	["Horion de givre"] = 1,
 	["Arme de givre"] = 1,
 
-	-- Same list, now in German
+	-- Spell names, in German
 	-- Forbidden fire spells
 	["Totem der Feuernova"] = 1,
 	["Flammenschock"] = 1,
@@ -38,7 +50,7 @@ local blacklist = {
 	["Frostschock"] = 1,
 	["Waffe des Frostbrands"] = 1,
 
-	-- Same list, now in Spanish
+	-- Spell names, in Spanish
 	-- Forbidden fire spells
 	["Tótem Nova de Fuego"] = 1,
 	["Choque de llamas"] = 1,
@@ -50,7 +62,7 @@ local blacklist = {
 	["Choque de Escarcha"] = 1,
 	["Arma Estigma de Escarcha"] = 1,
 
-	-- Same list, now in Portuguese
+	-- Spell names, in Portuguese
 	-- Forbidden fire spells
 	["Totem de Nova de Fogo"] = 1,
 	["Choque Flamejante"] = 1,
@@ -62,7 +74,7 @@ local blacklist = {
 	["Choque Gélido"] = 1,
 	["Arma da Marca Gélida"] = 1,
 
-	-- Same list, now in Russian
+	-- Spell names, in Russian
 	-- Forbidden fire spells
 	["Тотем кольца огня"] = 1,
 	["Огненный шок"] = 1,
@@ -74,7 +86,7 @@ local blacklist = {
 	["Ледяной шок"] = 1,
 	["Оружие ледяного клейма"] = 1,
 
-	-- Same list, now in Korean
+	-- Spell names, in Korean (untested)
 	-- Forbidden fire spells
 	["불꽃 회오리 토템"] = 1,
 	["화염 충격"] = 1,
@@ -86,7 +98,7 @@ local blacklist = {
 	["냉기 충격"] = 1,
 	["냉기의 무기"] = 1,
 
-	-- Same list, now in Chinese
+	-- Spell names, in Chinese (untested)
 	-- Forbidden fire spells
 	["火焰新星图腾"] = 1,
 	["烈焰震击"] = 1,

--- a/Achievements/Thunderstruck.lua
+++ b/Achievements/Thunderstruck.lua
@@ -8,11 +8,9 @@ local blacklist = {
 	["Flame Shock"] = 1,
 	["Flametongue Totem"] = 1,
 	["Flametongue Weapon"] = 1,
-	["Frost Resistance Totem"] = 1,
 	["Magma Totem"] = 1,
 	["Searing Totem"] = 1,
 	-- Forbidden frost spells
-	["Fire Resistance Totem"] = 1,
 	["Frost Shock"] = 1,
 	["Frostbrand Weapon"] = 1,
 
@@ -22,11 +20,9 @@ local blacklist = {
 	["Horion de flammes"] = 1,
 	["Totem Langue de feu"] = 1,
 	["Arme Langue de feu"] = 1,
-	["Totem de résistance au Givre"] = 1,
 	["Totem de Magma"] = 1,
 	["Totem incendiaire"] = 1,
 	-- Forbidden frost spells
-	["Totem de résistance au Feu"] = 1,
 	["Horion de givre"] = 1,
 	["Arme de givre"] = 1,
 
@@ -36,11 +32,9 @@ local blacklist = {
 	["Flammenschock"] = 1,
 	["Totem der Flammenzunge"] = 1,
 	["Waffe der Flammenzunge"] = 1,
-	["Totem des Frostwiderstands"] = 1,
 	["Totem der glühenden Magma"] = 1,
 	["Totem der Verbrennung"] = 1,
 	-- Forbidden frost spells
-	["Totem des Feuerwiderstands"] = 1,
 	["Frostschock"] = 1,
 	["Waffe des Frostbrands"] = 1,
 
@@ -50,11 +44,9 @@ local blacklist = {
 	["Choque de llamas"] = 1,
 	["Tótem lengua de Fuego"] = 1,
 	["Arma lengua de Fuego"] = 1,
-	["Tótem de resistencia a la Escarcha"] = 1,
 	["Tótem de magma"] = 1,
 	["Tótem abrasador"] = 1,
 	-- Forbidden frost spells
-	["Tótem de Resistencia al Fuego"] = 1,
 	["Choque de Escarcha"] = 1,
 	["Arma Estigma de Escarcha"] = 1,
 
@@ -65,11 +57,9 @@ local blacklist = {
 	["Folgore del Fuoco"] = 1,
 	["Totem della Lingua di Fuoco"] = 1,
 	["Arma della Lingua di Fuoco"] = 1,
---	["Frost Resistance Totem"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
 	["Totem del Magma"] = 1,
 	["Totem delle Fiamme"] = 1,
 	-- Forbidden frost spells
---	["Fire Resistance Totem"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
 	["Folgore del Gelo"] = 1,
 --	["Frostbrand Weapon"] = 1, -- Unkown Italian translation in both Wowhead Classic and Wowhead Retail
 
@@ -79,11 +69,9 @@ local blacklist = {
 	["Choque Flamejante"] = 1,
 	["Totem de Labaredas"] = 1,
 	["Arma de Labaredas"] = 1,
-	["Totem de Resistência ao Gelo"] = 1,
 --	["Totem de Magma"] = 1, -- Same as French
 	["Totem Calcinante"] = 1,
 	-- Forbidden frost spells
-	["Totem de Resistência ao Fogo"] = 1,
 	["Choque Gélido"] = 1,
 	["Arma da Marca Gélida"] = 1,
 
@@ -93,11 +81,9 @@ local blacklist = {
 	["Огненный шок"] = 1,
 	["Тотем языка пламени"] = 1,
 	["Оружие языка пламени"] = 1,
-	["Тотем сопротивления льду"] = 1,
 	["Тотем магмы"] = 1,
 	["Опаляющий тотем"] = 1,
 	-- Forbidden frost spells
-	["Тотем сопротивления огню"] = 1,
 	["Ледяной шок"] = 1,
 	["Оружие ледяного клейма"] = 1,
 
@@ -107,11 +93,9 @@ local blacklist = {
 	["화염 충격"] = 1,
 	["불꽃의 토템"] = 1,
 	["불꽃의 무기"] = 1,
-	["냉기 저항 토템"] = 1,
 	["용암 토템"] = 1,
 	["불타는 토템"] = 1,
 	-- Forbidden frost spells
-	["화염 저항 토템"] = 1,
 	["냉기 충격"] = 1,
 	["냉기의 무기"] = 1,
 
@@ -121,11 +105,9 @@ local blacklist = {
 	["烈焰震击"] = 1,
 	["火舌图腾"] = 1,
 	["火舌武器"] = 1,
-	["抗寒图腾"] = 1,
 	["熔岩图腾"] = 1,
 	["灼热图腾"] = 1,
 	-- Forbidden frost spells
-	["抗火图腾"] = 1,
 	["冰霜震击"] = 1,
 	["冰封武器"] = 1,
 }


### PR DESCRIPTION
Implements #478 and removes false positives.

## Language support

The following languages are supported and were tested (translations gathered from the game client):
- Portuguese
- Russian

The following languages are supported, but not tested (translations from Wowhead):
- Korean
- Chinese
   - for the record, Wowhead does not distinguish Chinese Simplified and Traditional
   - ideally, a player who can run the game with these languages should use the test code
   - (to do so, please read the big comment on top of Thunderstruck.lua)

The following languages are _not_ supported:
- Italian
   - there is not such thing as an Italian game client for Classic Era nor Wrath Classic

Additionally, the following languages were double-checked:
- English
- French
- German
- Spanish

## False positives

Because the Thunderstruck achievement states that the shaman is not allowed to cast non-Nature damaging spells and totems, the following totems are no longer blacklisted because they do not deal damage:
- Frost Resistance Totem
- Fire Resistance Totem

For the record, other non-damaging fire or water totems were already excluded from the blacklist, such as Healing Stream Totem.