### PR TITLE
Reload reminder

### DIFF
--- a/Dungeons.lua
+++ b/Dungeons.lua
@@ -1606,6 +1606,9 @@ local function DungeonTracker()
 		DungeonTrackerUpgradeLogVersion3()
 	end
 
+	-- Tell the watchdog we are still alive
+	ReloadReminderDungeonTrackerUpdate()
+
 	-- Sometimes, runs don't get logged correctly, like when they are pending and the addon is updated to a version
 	-- with a different format or when runs are deleted through appeal commands. In those cases, runs might disappear
 	-- entirely, while they should be there. We check for any missing or mergeable runs exactly once per session.

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -1632,6 +1632,7 @@ function Hardcore:TIME_PLAYED_MSG(...)
 
 	Hardcore:Debug(Hardcore_Character.tracked_played_percentage)
 
+	-- Tell the watchdog we are still alive
 	ReloadReminderPlayedTimeUpdate()
 
 	-- Check to see if the gap since the last recording is too long.  When receiving played time for the first time.
@@ -3328,6 +3329,8 @@ function Hardcore:InitiatePulsePlayed()
 		if RECEIVED_FIRST_PLAYED_TIME_MSG == true then
 			Hardcore_Character.accumulated_time_diff = Hardcore_Character.time_played - Hardcore_Character.time_tracked
 		end
+		-- Tell the watchdog we are still alive
+		ReloadReminderTrackedTimeUpdate()
 	end)
 
 	--played time tracking

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -3996,7 +3996,7 @@ local options = {
 				reload_reminder_interval = {
 					type = "input",
 					name = "Reminder interval",
-					desc = "Reload reminder interval (in seconds, 0 = auto)",
+					desc = "Reload reminder interval (in minutes, 0 = automatic)",
 					get = function()
 						if Hardcore_Settings.reload_reminder_interval then
 							return "" .. Hardcore_Settings.reload_reminder_interval

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -73,6 +73,8 @@ Hardcore_Settings = {
 	ignore_xguild_chat = false,
 	ignore_xguild_alerts = false,
 	global_custom_pronoun = false,
+	reload_reminder_interval = 0,
+	reload_reminder_show = true
 }
 
 WARNING = ""
@@ -544,6 +546,8 @@ local settings_saved_variable_meta = {
 	["use_alternative_menu"] = false,
 	["ignore_xguild_chat"] = false,
 	["ignore_xguild_alerts"] = false,
+	["reload_reminder_interval"] = 0,
+	["reload_reminder_show"] = true,
 }
 
 --[[ Post-utility functions]]
@@ -987,6 +991,9 @@ function Hardcore:PLAYER_LOGIN()
 
 	-- initiate survey module (pass Hardcore.lua locals needed for communication)
 	SurveyInitiate(COMM_NAME, COMM_COMMANDS[18], COMM_COMMANDS[19], COMM_COMMAND_DELIM, COMM_FIELD_DELIM)
+
+	-- initiate reload reminder module
+	ReloadReminderInitiate()
 
 	-- check players version against highest version
 	local FULL_PLAYER_NAME = Hardcore_GetPlayerPlusRealmName()
@@ -1624,6 +1631,8 @@ function Hardcore:TIME_PLAYED_MSG(...)
 	end
 
 	Hardcore:Debug(Hardcore_Character.tracked_played_percentage)
+
+	ReloadReminderPlayedTimeUpdate()
 
 	-- Check to see if the gap since the last recording is too long.  When receiving played time for the first time.
 	if RECEIVED_FIRST_PLAYED_TIME_MSG == false and Hardcore_Character.accumulated_time_diff ~= nil then
@@ -3927,7 +3936,7 @@ local options = {
 						Hardcore_Settings.hardcore_player_name = val
 						Hardcore_Character.hardcore_player_name = val
 					end,
-					order = 11,
+					order = 13,
 				},
 				use_alternative_menu = {
 					type = "toggle",
@@ -3939,7 +3948,7 @@ local options = {
 					set = function()
 						Hardcore_Settings.use_alternative_menu = not Hardcore_Settings.use_alternative_menu
 					end,
-					order = 12,
+					order = 11,
 				},
 				show_minimap_icon_option = {
 					type = "toggle",
@@ -3951,14 +3960,46 @@ local options = {
 					set = function()
 						Hardcore:ToggleMinimapIcon()
 					end,
-					order = 13,
+					order = 12,
+				},
+				reload_reminder_show = {
+					type = "toggle",
+					name = "Show reload reminder",
+					desc = "Show reload reminder",
+					get = function()
+						return Hardcore_Settings.reload_reminder_show
+					end,
+					set = function()
+						Hardcore_Settings.reload_reminder_show = not Hardcore_Settings.reload_reminder_show
+						ReloadReminderEnableWarning(Hardcore_Settings.reload_reminder_show)
+					end,
+					order = 14,
+				},
+				reload_reminder_interval = {
+					type = "input",
+					name = "Reminder interval",
+					desc = "Reload reminder interval (in seconds, 0 = auto)",
+					get = function()
+						if Hardcore_Settings.reload_reminder_interval then
+							return "" .. Hardcore_Settings.reload_reminder_interval
+						else
+							return "0"
+						end
+					end,
+					set = function(info, val)
+						if tonumber( val ) and tonumber(val) >= 0 then
+							Hardcore_Settings.reload_reminder_interval = tonumber(val)
+							ReloadReminderSetInterval( tonumber(val) )
+						end
+					end,
+					order = 15,
 				},
 			},
 		},
 		cross_guild_header = {
 			type = "group",
 			name = "Cross-Guild",
-			order = 14,
+			order = 16,
 			inline = true,
 			args = {
 				ignore_xguild_chat = {
@@ -3972,7 +4013,7 @@ local options = {
 					set = function()
 						Hardcore_Settings.ignore_xguild_chat = not Hardcore_Settings.ignore_xguild_chat
 					end,
-					order = 15,
+					order = 17,
 				},
 				ignore_xguild_alerts = {
 					type = "toggle",
@@ -3984,7 +4025,7 @@ local options = {
 					set = function()
 						Hardcore_Settings.ignore_xguild_alerts = not Hardcore_Settings.ignore_xguild_alerts
 					end,
-					order = 17,
+					order = 18,
 				},
 			},
 		},
@@ -4006,6 +4047,8 @@ local options = {
 				Hardcore_Settings.show_minimap_mailbox_icon = false
 				Hardcore_Settings.ignore_xguild_alerts = false
 				Hardcore_Settings.ignore_xguild_chat = false
+				Hardcore_Settings.reload_reminder_show = true
+				Hardcore_Settings.reload_reminder_interval = 0				
 				Hardcore:ApplyAlertFrameSettings()
 			end,
 			order = 20,

--- a/Hardcore_Classic.toc
+++ b/Hardcore_Classic.toc
@@ -156,6 +156,7 @@ AchievementTab.lua
 FirstMenuScreen.lua
 Dungeons.lua
 Survey.lua
+ReloadReminder.lua
 MainMenu.lua
 TextureUtils.lua
 TextureInfo.lua

--- a/Hardcore_Classic.toc
+++ b/Hardcore_Classic.toc
@@ -154,9 +154,9 @@ CharacterStatusScreen.lua
 InspectStatusScreen.lua
 AchievementTab.lua
 FirstMenuScreen.lua
+ReloadReminder.lua
 Dungeons.lua
 Survey.lua
-ReloadReminder.lua
 MainMenu.lua
 TextureUtils.lua
 TextureInfo.lua

--- a/Hardcore_Wrath.toc
+++ b/Hardcore_Wrath.toc
@@ -156,6 +156,7 @@ AchievementTab.lua
 FirstMenuScreen.lua
 Dungeons.lua
 Survey.lua
+ReloadReminder.lua
 MainMenu.lua
 TextureUtils.lua
 TextureInfo.lua

--- a/Hardcore_Wrath.toc
+++ b/Hardcore_Wrath.toc
@@ -154,9 +154,9 @@ CharacterStatusScreen.lua
 InspectStatusScreen.lua
 AchievementTab.lua
 FirstMenuScreen.lua
+ReloadReminder.lua
 Dungeons.lua
 Survey.lua
-ReloadReminder.lua
 MainMenu.lua
 TextureUtils.lua
 TextureInfo.lua

--- a/ReloadReminder.lua
+++ b/ReloadReminder.lua
@@ -6,8 +6,8 @@
 
 local AceGUI = LibStub("AceGUI-3.0")
 
-local rr_last_reload = 0                -- Last time of a reload (basically, last time since ReloadReminderInitiate())
-local rr_last_warning = 0               -- Last time of an actually output warning
+local rr_last_reload = 0               -- Last time of a reload (basically, last time since ReloadReminderInitiate())
+local rr_last_warning = 0              -- Last time of an actually output warning
 local rr_last_played_heartbeat = 0     -- Last time of a PLAYED_TIME_MSG in Hardcore.lua
 local rr_last_track_heartbeat = 0      -- Last time of a tracked time ticker in Hardcore.lua
 local rr_last_dung_heartbeat = 0       -- Last time of a dungeon ticker in Hardcore.lua
@@ -25,17 +25,17 @@ local RR_LOST_VS_AUTO_INTERVAL = {
     { 3600, 3600 },         -- With less than 1 hour of lost time, warn every hour
     { 7200, 2700 },         -- With 1-2 hours of lost time, warn every 45m
     {10800, 1800 },         -- With 2-3 hours of lost time, warn every 30m
-    {   -1,  900 }          -- All other cases: warn every 15m; this is crazy, really... You're reloading mroe than playing. But okay, this is just a warning
+    {   -1,  900 }          -- All other cases: warn every 15m
 }
 
 -- debug values
 if false then
     RR_WARN_SUPPRESS = 5
     RR_LOST_VS_AUTO_INTERVAL = {
-        { 3600, 15 },         -- With less than 1 hour of lost time, warn every hour
-        { 7200, 20 },         -- With 1-2 hours of lost time, warn every 45m
-        { 1800, 10 },         -- With 2-3 hours of lost time, warn every 30m
-        {   -1, 5 }           -- All other cases: warn every 15m; this is crazy, really... You're reloading mroe than playing. But okay, this is just a warning
+        { 3600, 30 },
+        { 7200, 20 },
+        {10800, 10 },
+        {   -1,  5 }
     }
 end
 

--- a/ReloadReminder.lua
+++ b/ReloadReminder.lua
@@ -1,0 +1,186 @@
+-- ReloadReminder.lua
+-- Reload reminder for the WOW Hardcore addon
+-- Written by Frank de Jong
+
+----- LOCAL VARIABLES ----------
+
+local rr_last_reload = 0                -- Last time of a reload (basically, last time since ReloadReminderInitiate())
+local rr_last_warning = 0               -- Last time of an actually output warning
+local rr_last_played_msg = 0            -- Last time of a PLAYED_TIME_MSG in Hardcore.lua
+
+-- These variables correspond to the HC options
+local rr_show_warning = true
+local rr_set_interval = 0               -- 0 indicates automatic
+
+-- Definitions
+local RR_TIME_STEP = 1                  -- How often our timer is called
+local RR_WARN_SUPPRESS = 60             -- How long to wait before another warning is output, to prevent spamming the user
+
+
+
+local RR_LOST_VS_AUTO_INTERVAL = {
+    { 3600, 3600 },         -- With less than 1 hour of lost time, warn every hour
+    { 7200, 2700 },         -- With 1-2 hours of lost time, warn every 45m
+    {10800, 1800 },         -- With 2-3 hours of lost time, warn every 30m
+    {   -1,  900 }          -- All other cases: warn every 15m; this is crazy, really... You're reloading mroe than playing. But okay, this is just a warning
+}
+
+-- debug values
+if true then
+    RR_WARN_SUPPRESS = 3
+    RR_LOST_VS_AUTO_INTERVAL = {
+        {  60,  20 },         -- With less than 1 hour of lost time, warn every hour
+        { 120,  10 },         -- With 1-2 hours of lost time, warn every 45m
+        { 1800, 5 },         -- With 2-3 hours of lost time, warn every 30m
+        {   -1, 2 }          -- All other cases: warn every 15m; this is crazy, really... You're reloading mroe than playing. But okay, this is just a warning
+    }
+end
+
+----- LOCAL FUNCTIONS ----------
+
+-- ReloadReminderGetInterval()
+--
+-- Returns the option-set interval or an automatically determined value from RR_LOST_VS_AUTO_INTERVAL if option-set is 0
+
+local function ReloadReminderGetInterval( rr_lost_time )
+
+    if rr_set_interval <= 0 then
+        for _, v in ipairs( RR_LOST_VS_AUTO_INTERVAL ) do
+            if v[1] == -1 then
+                return v[2]             -- Last value in the array, always return this
+            end
+            if rr_lost_time <= v[1] then
+                return v[2]
+            end
+        end
+    end
+
+    return rr_set_interval
+
+end
+
+
+----- GLOBAL FUNCTIONS ----------
+
+
+-- ReloadReminderPlayedTimeUpdate()
+--
+-- Called from Hardcore:TIME_PLAYED_MSG(...) right after the /played time is updated
+-- This triggers the "best time to reload" message. We put as little as possible
+-- code here to prevent breaking the main tracked time timer
+
+function ReloadReminderPlayedTimeUpdate()
+
+    rr_last_played_msg = GetServerTime()
+
+end
+
+
+
+-- ReloadReminderCheck()
+--
+-- Timer function that gets called every second to check the conditions for
+-- advising a reload are met and putting out the advice
+
+function ReloadReminderCheck()
+
+    local rr_warn_interval = 0              -- Automatic or option-set time between a reload and a warning
+
+    if rr_show_warning == false then
+        return
+    end
+
+    -- Check if in combat, suppress the warning if so
+    if InCombatLockdown() == true then
+        return
+    end
+
+    -- Do some fool proofing now so we don't have to keep doing that later
+    if _G.Hardcore_Character == nil or _G.Hardcore_Character.time_played == nil or _G.Hardcore_Character.time_tracked == nil then
+        return
+    end
+
+    -- Determine what is a good time to advise a reload;
+    -- First determine how much tracked time was lost already
+    local rr_lost_time = _G.Hardcore_Character.time_played - _G.Hardcore_Character.time_tracked
+    if rr_lost_time < 0 then
+        rr_lost_time = 0
+    end
+
+    -- Now derive a good warning interval; 
+    rr_warn_interval = ReloadReminderGetInterval(rr_lost_time)
+
+    -- Now see if the interval has passed already
+    local now = GetServerTime()
+    if now - rr_last_reload < rr_warn_interval then
+        return
+    end
+
+    -- Don't warn more often than once per minute
+    if now - rr_last_warning < RR_WARN_SUPPRESS then
+        return
+    end
+
+    print( "5: " .. now .. "/" .. rr_last_played_msg )
+    -- Okay, so it's time to output a warning
+    -- But we don't advise the warning if the /played msg was received too long ago;
+    -- we want to do the advice right after the /played msg was received, so that most
+    -- data is up-to-date
+    if now - rr_last_played_msg > 10 then
+        return
+    end
+
+    -- Okay, let's output the warning
+    Hardcore:Print( "Time for a /reload, interval = " .. rr_warn_interval)
+    rr_last_warning = now
+
+end
+
+-- ReloadReminderEnableWarning( should_show )
+-- ReloadReminderSetInterval( interval )
+--
+-- Functions called to enable or disable the reload warning and set the interval
+
+function ReloadReminderEnableWarning( should_show )
+    rr_show_warning = should_show
+    Hardcore:Debug( "Reload reminder warning show is now " .. (rr_show_warning and 'true' or 'false') )
+end
+
+function ReloadReminderSetInterval( interval )
+    rr_set_interval = interval
+    Hardcore:Debug( "Reload reminder warning interval is now " .. rr_set_interval )
+end
+
+
+-- ReloadReminderInitiate()
+--
+-- Function to set up the reload reminder subsystem
+-- Called from Hardcore.lua as follows:
+
+function ReloadReminderInitiate()
+
+    -- Initiate our local variables
+    local now = GetServerTime()
+    rr_last_reload = now
+    rr_last_warning = now
+    rr_last_played_msg = now
+
+    -- Copy over the global setting
+    if _G.Hardcore_Settings ~= nil and _G.Hardcore_Settings.reload_reminder_show ~= nil then
+        ReloadReminderEnableWarning( _G.Hardcore_Settings.reload_reminder_show )
+    else
+        ReloadReminderEnableWarning( true )
+    end
+    if _G.Hardcore_Settings ~= nil and _G.Hardcore_Settings.reload_reminder_interval ~= nil then
+        ReloadReminderSetInterval( _G.Hardcore_Settings.reload_reminder_interval )
+    else
+        ReloadReminderSetInterval( 0 )
+    end
+
+    -- Start our timer
+	C_Timer.NewTicker(RR_TIME_STEP, function()
+		ReloadReminderCheck()
+	end)
+
+end
+

--- a/ReloadReminder.lua
+++ b/ReloadReminder.lua
@@ -26,7 +26,7 @@ local RR_LOST_VS_AUTO_INTERVAL = {
 }
 
 -- debug values
-if true then
+if false then
     RR_WARN_SUPPRESS = 3
     RR_LOST_VS_AUTO_INTERVAL = {
         {  60,  20 },         -- With less than 1 hour of lost time, warn every hour

--- a/ReloadReminder.lua
+++ b/ReloadReminder.lua
@@ -8,9 +8,9 @@ local AceGUI = LibStub("AceGUI-3.0")
 
 local rr_last_reload = 0                -- Last time of a reload (basically, last time since ReloadReminderInitiate())
 local rr_last_warning = 0               -- Last time of an actually output warning
-local rr_last_played_msg = 0            -- Last time of a PLAYED_TIME_MSG in Hardcore.lua
-local rr_last_track_msg = 0             -- Last time of a tracked time ticker in Hardcore.lua
-local rr_last_dung_msg = 0              -- Last time of a dungeon ticker in Hardcore.lua
+local rr_last_played_heartbeat = 0     -- Last time of a PLAYED_TIME_MSG in Hardcore.lua
+local rr_last_track_heartbeat = 0      -- Last time of a tracked time ticker in Hardcore.lua
+local rr_last_dung_heartbeat = 0       -- Last time of a dungeon ticker in Hardcore.lua
 local rr_frame
 
 -- These variables correspond to the HC options
@@ -30,9 +30,9 @@ local RR_LOST_VS_AUTO_INTERVAL = {
 
 -- debug values
 if false then
-    RR_WARN_SUPPRESS = 10
+    RR_WARN_SUPPRESS = 5
     RR_LOST_VS_AUTO_INTERVAL = {
-        { 3600, 30 },         -- With less than 1 hour of lost time, warn every hour
+        { 3600, 15 },         -- With less than 1 hour of lost time, warn every hour
         { 7200, 20 },         -- With 1-2 hours of lost time, warn every 45m
         { 1800, 10 },         -- With 2-3 hours of lost time, warn every 30m
         {   -1, 5 }           -- All other cases: warn every 15m; this is crazy, really... You're reloading mroe than playing. But okay, this is just a warning
@@ -47,6 +47,7 @@ end
 
 local function ReloadReminderGetInterval( rr_lost_time )
 
+    -- If set to automatic, we calculate a value
     if rr_set_interval <= 0 then
         for _, v in ipairs( RR_LOST_VS_AUTO_INTERVAL ) do
             if v[1] == -1 then
@@ -58,21 +59,69 @@ local function ReloadReminderGetInterval( rr_lost_time )
         end
     end
 
+    -- If set to some specific value, that's what we do
     return rr_set_interval
 
 end
 
+local function ReloadReminderSavePosition()
+
+    local _hc_settings = _G["Hardcore_Settings"]
+    if _hc_settings == nil or rr_frame == nil then
+        return
+    end
+
+    -- Create the settings if it doesn't exist already
+	if _hc_settings['reload_reminder_pos'] == nil then
+	  _hc_settings['reload_reminder_pos'] = {}
+	end
+
+	local point, _, _, x, y = rr_frame:GetPoint()
+
+	_hc_settings['reload_reminder_pos']['x'] = x
+	_hc_settings['reload_reminder_pos']['y'] = y
+    _hc_settings['reload_reminder_pos']['ref'] = point
+
+end
+
+local function ReloadReminderRestorePosition()
+
+    -- Fool proofing
+    if rr_frame == nil then
+        return
+    end
+
+    -- Set previous window position
+    local _hc_settings = _G["Hardcore_Settings"]
+    rr_frame:ClearAllPoints()
+    if _hc_settings["reload_reminder_pos"]
+        and _hc_settings["reload_reminder_pos"]["x"]
+        and _hc_settings["reload_reminder_pos"]["y"]
+        and _hc_settings["reload_reminder_pos"]['ref'] then
+        rr_frame:SetPoint(_hc_settings["reload_reminder_pos"]['ref'], _hc_settings["reload_reminder_pos"]['x'], _hc_settings["reload_reminder_pos"]['y'])
+    else
+        rr_frame:SetPoint("CENTER", 0, 0)
+    end
+
+end
+
+
 local function ReloadReminderDoReload()
 
-    Hardcore:Print("Attempting reload")    
+    ReloadReminderSavePosition()
+    Hardcore:Print("Attempting reload")
     ReloadUI()
     Hardcore:Print("Reload failed")
 
 end
 
+
 local function ReloadReminderCleanup(widget)
 
-    AceGUI:Release(widget) 
+    -- Store the postion where the window is at
+    ReloadReminderSavePosition()
+
+    AceGUI:Release(widget)
     rr_frame = nil
     rr_last_warning = GetServerTime()           -- Suppress warnings for maximum time from now
 
@@ -90,6 +139,8 @@ local function ReloadReminderCreateWindow()
         rr_frame:SetWidth(300)
         rr_frame:SetHeight(125)
 
+        ReloadReminderRestorePosition()
+
         local button = AceGUI:Create("Button")
         button:SetText("Reload now")
         button:SetWidth(250)
@@ -101,6 +152,43 @@ local function ReloadReminderCreateWindow()
 
 end
 
+local function ReloadReminderGetIntervalString( interval )
+
+    local time_str = ""
+    local num_hours = 0
+    local num_mins = 0
+
+    if interval >= 3600 then
+        num_hours = math.floor( interval / 3600 )
+        time_str = time_str .. num_hours .. " Hr"
+        if num_hours > 1 then
+            time_str = time_str .. "s"
+        end
+        interval = interval - (num_hours * 3600)
+    end
+    if interval >= 60 then
+        num_mins = math.floor( interval / 60 )
+        if num_hours > 0 then
+            time_str = time_str .. " "
+        end
+        time_str = time_str .. num_mins .. " Min"
+        if num_mins > 1 then
+            time_str = time_str .. "s"
+        end
+        interval = interval - (num_mins * 60)
+    end
+    if interval > 0 then
+        if num_hours > 0 or num_mins > 0 then
+            time_str = time_str .. " "
+        end
+        time_str = time_str .. interval .. " Sec"
+        if interval > 1 then
+            time_str = time_str .. "s"
+        end
+    end
+    return time_str
+
+end
 
 
 ----- GLOBAL FUNCTIONS ----------
@@ -114,17 +202,16 @@ end
 -- are still operational
 
 function ReloadReminderPlayedTimeUpdate()
-    rr_last_played_msg = GetServerTime()
+    rr_last_played_heartbeat = GetServerTime()
 end
 
 function ReloadReminderTrackedTimeUpdate()
-    rr_last_track_msg = GetServerTime()
+    rr_last_track_heartbeat = GetServerTime()
 end
 
 function ReloadReminderDungeonTrackerUpdate()
-    rr_last_dung_msg = GetServerTime()
+    rr_last_dung_heartbeat = GetServerTime()
 end
-
 
 
 -- ReloadReminderCheck()
@@ -159,9 +246,9 @@ function ReloadReminderCheck()
     end
 
     -- Check if any of the tickers are falling behind; if so, warn immediately
-    if (now - rr_last_played_msg > 180) or
-       (now - rr_last_track_msg > 180) or
-       (now - rr_last_dung_msg > 180) then
+    if (now - rr_last_played_heartbeat > 180) or
+       (now - rr_last_track_heartbeat > 180) or
+       (now - rr_last_dung_heartbeat > 180) then
         Hardcore:Print( "Detected a missing heartbeat -- a /reload is advised!")
         rr_last_warning = now
         ReloadReminderCreateWindow()
@@ -181,7 +268,7 @@ function ReloadReminderCheck()
     -- Now see if the interval has passed already
     if now - rr_last_reload > rr_warn_interval then
         -- Okay, let's output the warning
-        Hardcore:Print( "Time for a /reload, interval = " .. rr_warn_interval)
+        Hardcore:Print( "Time for a /reload, interval = " .. ReloadReminderGetIntervalString( rr_warn_interval) )
         rr_last_warning = now
         ReloadReminderCreateWindow()
     end
@@ -199,8 +286,8 @@ function ReloadReminderEnableWarning( should_show )
 end
 
 function ReloadReminderSetInterval( interval )
-    rr_set_interval = interval
-    Hardcore:Debug( "Reload reminder warning interval is now " .. rr_set_interval )
+    rr_set_interval = interval * 60
+    Hardcore:Debug( "Reload reminder warning interval is now " .. rr_set_interval .. " seconds")
 end
 
 
@@ -215,7 +302,6 @@ function ReloadReminderInitiate()
     local now = GetServerTime()
     rr_last_reload = now
     rr_last_warning = now
-    rr_last_played_msg = now
 
     -- Copy over the global setting
     if _G.Hardcore_Settings ~= nil and _G.Hardcore_Settings.reload_reminder_show ~= nil then
@@ -233,9 +319,6 @@ function ReloadReminderInitiate()
 	C_Timer.NewTicker(RR_TIME_STEP, function()
 		ReloadReminderCheck()
 	end)
-
-    -- Show the window when needed
-    --ReloadReminderCreateWindow()
 
 end
 

--- a/ReloadReminder.lua
+++ b/ReloadReminder.lua
@@ -12,6 +12,7 @@ local rr_last_played_heartbeat = 0     -- Last time of a PLAYED_TIME_MSG in Hard
 local rr_last_track_heartbeat = 0      -- Last time of a tracked time ticker in Hardcore.lua
 local rr_last_dung_heartbeat = 0       -- Last time of a dungeon ticker in Hardcore.lua
 local rr_frame
+local rr_num_times_closed = 0
 
 -- These variables correspond to the HC options
 local rr_show_warning = true
@@ -20,7 +21,6 @@ local rr_set_interval = 0               -- 0 indicates automatic
 -- Definitions
 local RR_TIME_STEP = 1                  -- How often our timer is called
 local RR_WARN_SUPPRESS = 60             -- How long to wait before another warning is output, to prevent spamming the user
-
 local RR_LOST_VS_AUTO_INTERVAL = {
     { 3600, 3600 },         -- With less than 1 hour of lost time, warn every hour
     { 7200, 2700 },         -- With 1-2 hours of lost time, warn every 45m
@@ -124,6 +124,14 @@ local function ReloadReminderCleanup(widget)
     AceGUI:Release(widget)
     rr_frame = nil
     rr_last_warning = GetServerTime()           -- Suppress warnings for maximum time from now
+
+    -- Tell the user that he can disable the reloader if he closes three times without reloading
+    rr_num_times_closed = rr_num_times_closed + 1
+    if rr_num_times_closed == 3 then
+        Hardcore:Print("You can customize and disable the reload reminder in the Hardcore options.")
+        Hardcore:Print("Using the reload reminder will mitigate data loss in case of DCs and crashes.")
+    end
+
 
 end
 


### PR DESCRIPTION
- Shows reload reminder after set time (or automatically based on difference between played and tracked time)
- Can be turned off in addon settings
- Window position remembered
- Heartbeat detection of tracked, played and dungeon timers