### PR TITLE
Update Dungeons.lua

### DIFF
--- a/Dungeons.lua
+++ b/Dungeons.lua
@@ -498,7 +498,7 @@ local function DungeonTrackerWarnInfraction()
 	local chat_color = "\124cffFF0000"
 
 	-- We only warn if there is still chance to get out in time
-	local time_left = DT_INSIDE_MAX_TIME - Hardcore_Character.dt.current.time_inside
+	local time_left = DT_INSIDE_MAX_TIME_NO_KILLS - Hardcore_Character.dt.current.time_inside
 	if time_left <= 0 then
 		return
 	end


### PR DESCRIPTION
- Warn for a longer time; some people may miss the warning in the first minute when they don't know an IID yet.