### PR TITLE
Cataclysm emergency patch

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -870,6 +870,10 @@ function Hardcore:PLAYER_LOGIN()
 	-- 	end
 	--     end
 	-- end)
+
+	-- DISABLE CHARACTER TAB FOR CATA PRE-PATCH
+	if _G["HardcoreBuildLabel"] ~= "Cata" then
+
 	-- Adds HC character tab functionality
 	hooksecurefunc("CharacterFrameTab_OnClick", function(self, button)
 		local name = self:GetName()
@@ -912,6 +916,8 @@ function Hardcore:PLAYER_LOGIN()
 		end
 	end)
 
+	end
+
 	-- fires on first loading
 	self:RegisterEvent("PLAYER_UNGHOST")
 	self:RegisterEvent("PLAYER_ALIVE")
@@ -937,7 +943,10 @@ function Hardcore:PLAYER_LOGIN()
 	self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 
 	-- For inspecting other player's status
+	-- INSPECT READY DISABLED FOR CATA PRE-PATCH
+	if _G["HardcoreBuildLabel"] ~= "Cata" then
 	self:RegisterEvent("INSPECT_READY")
+	end
 	self:RegisterEvent("UNIT_TARGET")
 	self:RegisterEvent("UPDATE_MOUSEOVER_UNIT")
 

--- a/Hardcore_Cata.toc
+++ b/Hardcore_Cata.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 40400
 ## Title: Hardcore 0.11.50
 ## Notes: Supports Classic Hardcore
 ## Author: The Classic Hardcore team, Molikar (Sean Kennedy), Mark Rogaski <stigg@aie-guild.org> as GreenWall author
@@ -13,7 +13,6 @@
 
 embeds.xml
 
-Libs/ascii85/ascii85.lua
 CustomLayouts.lua
 utils.lua
 Security.lua
@@ -28,10 +27,9 @@ Achievements/AchievementG.lua
 Achievements/Solo.lua
 Achievements/Duo.lua
 Achievements/Trio.lua
+Achievements/Heirlooms.lua
 #Begin achievement modules
 Achievements/Arcanist.lua
-Achievements/FireAndFrost.lua
-Achievements/ShadowAndFlame.lua
 Achievements/AnimalFriend.lua
 Achievements/Berserker.lua
 Achievements/Bloodbath.lua
@@ -39,6 +37,8 @@ Achievements/CloseCombat.lua
 Achievements/Cyromancer.lua
 Achievements/DruidOfTheClaw.lua
 Achievements/Ephemeral.lua
+Achievements/FireAndFrost.lua
+Achievements/ShadowAndFlame.lua
 Achievements/Felfire.lua
 Achievements/Grounded.lua
 Achievements/Hammertime.lua
@@ -113,7 +113,6 @@ Achievements/MasterHerbalism.lua
 Achievements/MasterFishing.lua
 Achievements/MasterCooking.lua
 Achievements/MasterFirstAid.lua
-Achievements/Parkour.lua
 Achievements/Tainted.lua
 Achievements/TheDungeonCrawler.lua
 Achievements/SpeedrunnerTen.lua
@@ -163,11 +162,10 @@ MainMenu.lua
 TextureUtils.lua
 TextureInfo.lua
 AchievementAlertFrame.lua
-id_to_npc_classic.lua
-npc_to_id_classic.lua
+id_to_npc.lua
+npc_to_id.lua
 DeathLog.lua
 SlashCommands.lua
-LevelToast.lua
 Hardcore.lua
 
 Libs/GreenWall/Constants.lua

--- a/Hardcore_Wrath.toc
+++ b/Hardcore_Wrath.toc
@@ -1,10 +1,10 @@
 ## Interface: 30403
-## Title: Hardcore 0.11.49
+## Title: Hardcore 0.11.50
 ## Notes: Supports Classic Hardcore
 ## Author: The Classic Hardcore team, Molikar (Sean Kennedy), Mark Rogaski <stigg@aie-guild.org> as GreenWall author
 ## X-License: All Rights Reserved
 ## X-Category: Leveling,Guild
-## Version: 0.11.49
+## Version: 0.11.50
 
 
 ## DefaultState: enabled

--- a/MainMenu.lua
+++ b/MainMenu.lua
@@ -308,6 +308,12 @@ local function DrawGeneralTab(container)
 	changelog_title:SetFont("Interface\\Addons\\Hardcore\\Media\\BreatheFire.ttf", 20, "")
 	scroll_frame:AddChild(changelog_title)
 
+	CreateHeadingLabel("11.50", scroll_frame)
+	CreateDescriptionLabel(
+		"- Emergency patch for Cataclysm",
+		scroll_frame
+	)
+
 	CreateHeadingLabel("11.49", scroll_frame)
 	CreateDescriptionLabel(
 		"- Added handling of Fury of Frostmourne spell (WoTLK)",

--- a/utils.lua
+++ b/utils.lua
@@ -1,6 +1,8 @@
 _G["HardcoreBuildLabel"] = nil
 local build_num = select(4, GetBuildInfo())
-if build_num > 29999 then
+if build_num > 39999 then
+	_G["HardcoreBuildLabel"] = "Cata"
+elseif build_num > 29999 then
 	_G["HardcoreBuildLabel"] = "WotLK"
 elseif build_num > 19999 then
 	_G["HardcoreBuildLabel"] = "TBC"


### PR DESCRIPTION
- Added recognition of Cataclysm (_G["HardcoreBuildLabel"]="Cata")
- Added .TOC for Cataclysm
- Temporarily disabled broken HC tab for Cataclysm