### PR TITLE
Cataclysm achievement patches

### DIFF
--- a/Achievements/FireAndFrost.lua
+++ b/Achievements/FireAndFrost.lua
@@ -11,6 +11,10 @@ _achievement.bl_text = "Starting Achievement"
 _achievement.description =
 	"Complete the Hardcore challenge without at any point casting two elemental damage spells of the same element (fire or ice) in a row. Arcane spells that deal damage are not allowed to be cast."
 
+_achievement.restricted_game_versions = {
+	["Cata"] = 1,			-- SetPropagateKeyboardInput function is protected in Cataclysm, can't call it from within combat
+}
+
 local fire_and_frost_frame = nil
 local frame_textures = {}
 

--- a/Achievements/NoHit.lua
+++ b/Achievements/NoHit.lua
@@ -13,6 +13,10 @@ no_hit_achievement.class = "All"
 no_hit_achievement.alert_on_fail = 1
 
 local faction_indices = { 2, 3, 4, 5 }
+
+local faction_ids_horde = { 68, 76, 81, 530}
+local faction_ids_alliance = { 47, 54, 69, 72}
+
 local starting_rep = {
 	["Gnome"] = 13300,
 	["Human"] = 13300,
@@ -22,18 +26,37 @@ local starting_rep = {
 	["Tauren"] = 10700,
 	["Orc"] = 10700,
 	["Troll"] = 10700,
+	["Blood Elf"] = 500 + 500 + 500 + 3100,
+	["Goblin"] = 3100 + 3100 + 3100 + 500,
+	["Draenei"] = 3100 + 3100 + 3100 + 3100,
+	["Worgen"] = 3100 + 3100 + 3100 + 3100
 }
 
 function no_hit_achievement:UpdateDescription()
 	no_hit_achievement.description =
 		"Complete the hardcore challenge without taking a point of damage.  Falling, drowning, fatigue and other such sources that count as “Environmental Damage” according to the Combat Log are, as such, Damage. This also means that spells that expend life as a resource, such as the Warlock’s Life Tap, do not cause any 'damage' and are as such perfectly viable.  Futhermore, you must accumulate over 45,000 reputation across the four main factions."
 	local total_earned_value = 0
-	for _, idx in ipairs(faction_indices) do
+	local faction_ids
+	local player_faction_group, _ = UnitFactionGroup( "player")
+	if player_faction_group == "Horde" then
+		faction_ids = faction_ids_horde
+	elseif player_faction_group == "Alliance" then
+		faction_ids = faction_ids_alliance
+	else
+		faction_ids = {}
+		Hardcore:Print( "Warning: player's faction is unexpected")
+	end
+	for _, idx in ipairs(faction_ids) do
 		local name, description, standingId, bottomValue, topValue, earnedValue, atWarWith, canToggleAtWar, isHeader, isCollapsed, hasRep, isWatched, isChild =
-			GetFactionInfo(idx)
+			GetFactionInfoByID(idx)
 		total_earned_value = total_earned_value + earnedValue
 	end
-	total_earned_value = total_earned_value - starting_rep[UnitRace("player")]
+	if starting_rep[UnitRace("player")] == nil then
+		total_earned_value = total_earned_value - starting_rep["Human"]
+		Hardcore:Print( "Warning: no starting reputation for race " .. UnitRace("player"))
+	else
+		total_earned_value = total_earned_value - starting_rep[UnitRace("player")]
+	end
 	if total_earned_value > 45000 then
 		no_hit_achievement.description = no_hit_achievement.description .. "\n|c0000FF00Progress: Complete!|r"
 	else

--- a/Achievements/Scavenger.lua
+++ b/Achievements/Scavenger.lua
@@ -10,6 +10,13 @@ scavenger_achievement.pts = 20
 scavenger_achievement.icon_path = "Interface\\Addons\\Hardcore\\Media\\icon_scavenger.blp"
 scavenger_achievement.description =
 	"Complete the Hardcore challenge without at any point using, consuming, or equipping an item that you have not looted from a mob, chest, or loot container, or crafted or conjured yourself. You are not allowed to ever buy any items from vendors, nor use, consume, or equip items rewarded by a quest (items provided for a quest can be used, consumed, or equipped). This includes consumables, projectiles, trade goods, and containers. All items you start with can be used, consumed, and equipped, including Hearthstone."
+-- Disable achievemnt until the problems with a /reload after vendor purchase and quest completion are fixed
+scavenger_achievement.restricted_game_versions = {
+	["Classic"] = 1,
+	["TBC"] = 1,
+	["WotLK"] = 1,
+	["Cata"] = 1,
+}
 scavenger_achievement.blacklist = {}
 
 -- Internal states

--- a/Achievements/Scavenger.lua
+++ b/Achievements/Scavenger.lua
@@ -10,14 +10,15 @@ scavenger_achievement.pts = 20
 scavenger_achievement.icon_path = "Interface\\Addons\\Hardcore\\Media\\icon_scavenger.blp"
 scavenger_achievement.description =
 	"Complete the Hardcore challenge without at any point using, consuming, or equipping an item that you have not looted from a mob, chest, or loot container, or crafted or conjured yourself. You are not allowed to ever buy any items from vendors, nor use, consume, or equip items rewarded by a quest (items provided for a quest can be used, consumed, or equipped). This includes consumables, projectiles, trade goods, and containers. All items you start with can be used, consumed, and equipped, including Hearthstone."
--- Disable achievemnt until the problems with a /reload after vendor purchase and quest completion are fixed
+
+-- Disable achievement until we find a way to put "choice rewards" onto the blacklist
 scavenger_achievement.restricted_game_versions = {
 	["Classic"] = 1,
 	["TBC"] = 1,
 	["WotLK"] = 1,
 	["Cata"] = 1,
 }
-scavenger_achievement.blacklist = {}
+scavenger_achievement.blacklist = nil			-- Performance improvement -- generate blacklist only when needed
 
 -- Internal states
 scavenger_achievement.item_pushed = false
@@ -33,7 +34,8 @@ function scavenger_achievement:Register(fail_function_executor)
 	scavenger_achievement:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	scavenger_achievement:RegisterEvent("MERCHANT_UPDATE")
 	scavenger_achievement:RegisterEvent("ITEM_PUSH")
-	scavenger_achievement:GenerateBlacklist()
+	scavenger_achievement:RegisterEvent("QUEST_TURNED_IN")
+--	scavenger_achievement:GenerateBlacklist()			-- delayed to when we actually need it
 	scavenger_achievement.fail_function_executor = fail_function_executor
 
 	scavenger_achievement.item_pushed = false
@@ -52,15 +54,25 @@ function scavenger_achievement:Unregister()
 	scavenger_achievement.active = false
 end
 
-function scavenger_achievement:GenerateBlacklist()
-	local completed = GetQuestsCompleted()
-	for i, v in pairs(completed) do
-		for g = 1, 10 do
+local function AddQuestItemsToBlacklist( quest_id )
+	if scavenger_achievement.blacklist == nil then
+		scavenger_achievement.blacklist = {}
+	end
+	if quest_id ~= nil then
+		local num_items = GetNumQuestLogRewards( quest_id )
+		for g = 1, num_items do
 			local itemName, itemTexture, numItems, quality, isUsable, itemID = GetQuestLogRewardInfo(g, i)
 			if itemName then
 				scavenger_achievement.blacklist[itemName] = 1
 			end
 		end
+	end
+end
+
+function scavenger_achievement:GenerateBlacklist()
+	local completed = GetQuestsCompleted()
+	for i, _ in pairs(completed) do
+		AddQuestItemsToBlacklist(i)
 	end
 end
 
@@ -112,11 +124,21 @@ scavenger_achievement:SetScript("OnEvent", function(self, event, ...)
 		if arg[2] == true then
 			return
 		end
+		-- Performance improvement -- generate the blacklist now that we actually need it
+		if scavenger_achievement.blacklist == nil then
+			scavenger_achievement:GenerateBlacklist()
+		end
 		local item_id = GetInventoryItemID("player", arg[1])
 		local item_name, _, _, _, _, item_type, item_subtype, _, _, _, _ = GetItemInfo(item_id)
 		if scavenger_achievement.blacklist[item_name] ~= nil then
-			Hardcore:Print("Equiped quest reward " .. item_name .. ".")
+			Hardcore:Print("Equipped quest reward " .. item_name .. ".")
 			scavenger_achievement.fail_function_executor.Fail(scavenger_achievement.name)
+		end
+	elseif event == "QUEST_TURNED_IN" then
+		--Hardcore:Print("Adding items to blacklist")
+		local quest_id = arg[1]
+		if quest_id ~= nil then
+			AddQuestItemsToBlacklist( quest_id )
 		end
 	end
 end)

--- a/Achievements/ShadowAndFlame.lua
+++ b/Achievements/ShadowAndFlame.lua
@@ -287,6 +287,7 @@ function _achievement:GatherSpellList()
 		local name, texture, offset, numSlots, isGuild, offspecID = GetSpellTabInfo(i)
 		for j = offset + 1, offset + numSlots do
 			local _,_,_,_,_,_,id = GetSpellInfo(j, "")
+			if id == nil then goto next_spell end
 			if flame_spells[id] == nil then
 			  shadow_spells[id] = 1
 			  local action_slots = C_ActionBar.FindSpellActionButtons(id)
@@ -303,6 +304,7 @@ function _achievement:GatherSpellList()
 			    end
 			  end
 			end
+			::next_spell::
 		end
 	end
 end

--- a/Achievements/ShadowAndFlame.lua
+++ b/Achievements/ShadowAndFlame.lua
@@ -11,6 +11,10 @@ _achievement.bl_text = "Starting Achievement"
 _achievement.description =
 	"Complete the Hardcore challenge without at any point casting two shadow or two flame spells in a row during combat."
 
+_achievement.restricted_game_versions = {
+	["Cata"] = 1,			-- SetPropagateKeyboardInput function is protected in Cataclysm, can't call it from within combat
+}
+
 local shadow_and_flame_frame = nil
 local frame_textures = {}
 

--- a/Achievements/ShadowAndFlame.lua
+++ b/Achievements/ShadowAndFlame.lua
@@ -286,8 +286,8 @@ function _achievement:GatherSpellList()
 	for i = 2, 4 do
 		local name, texture, offset, numSlots, isGuild, offspecID = GetSpellTabInfo(i)
 		for j = offset + 1, offset + numSlots do
-			local _,_,_,_,_,_,id = GetSpellInfo(j, "")
-			if id == nil then goto next_spell end
+		  local _,_,_,_,_,_,id = GetSpellInfo(j, "")
+		  if id ~= nil then 
 			if flame_spells[id] == nil then
 			  shadow_spells[id] = 1
 			  local action_slots = C_ActionBar.FindSpellActionButtons(id)
@@ -304,7 +304,7 @@ function _achievement:GatherSpellList()
 			    end
 			  end
 			end
-			::next_spell::
+		  end
 		end
 	end
 end

--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -994,7 +994,10 @@ function Hardcore:PLAYER_LOGIN()
 		end
 	end
 	for i, v in pairs(_G.passive_achievements) do
-		v:Register(success_function_executor, Hardcore_Character)
+		-- Only register passive detection for the ones that are actually allowed in this version of the game
+		if v.restricted_game_versions == nil or v.restricted_game_versions[ _G["HardcoreBuildLabel"]] == nil then
+			v:Register(success_function_executor, Hardcore_Character)
+		end
 	end
 	if any_acheivement_registered then
 		Hardcore:Print(


### PR DESCRIPTION
- Disabled non-functional spell school changing achievements FireAndFrost and ShadowAndFlame for Cata
- Disabled easily fooled Scavenger achievement for all versions
- Fixed NoHit achievement (starting rep for new races)
- Removed registering of event callbacks for passive achievements that are not available for a particular game version.